### PR TITLE
servers: views: Return LeaseState to speed up invalidation.

### DIFF
--- a/cpp/generated/xtreemfs/GlobalTypes.pb.cc
+++ b/cpp/generated/xtreemfs/GlobalTypes.pb.cc
@@ -59,6 +59,7 @@ const ::google::protobuf::EnumDescriptor* OSDSelectionPolicyType_descriptor_ = N
 const ::google::protobuf::EnumDescriptor* ReplicaSelectionPolicyType_descriptor_ = NULL;
 const ::google::protobuf::EnumDescriptor* SnapConfig_descriptor_ = NULL;
 const ::google::protobuf::EnumDescriptor* StripingPolicyType_descriptor_ = NULL;
+const ::google::protobuf::EnumDescriptor* LeaseState_descriptor_ = NULL;
 const ::google::protobuf::EnumDescriptor* PORTS_descriptor_ = NULL;
 const ::google::protobuf::EnumDescriptor* CONSTANTS_descriptor_ = NULL;
 const ::google::protobuf::EnumDescriptor* SYSTEM_V_FCNTL_descriptor_ = NULL;
@@ -267,11 +268,12 @@ void protobuf_AssignDesc_xtreemfs_2fGlobalTypes_2eproto() {
   ReplicaSelectionPolicyType_descriptor_ = file->enum_type(2);
   SnapConfig_descriptor_ = file->enum_type(3);
   StripingPolicyType_descriptor_ = file->enum_type(4);
-  PORTS_descriptor_ = file->enum_type(5);
-  CONSTANTS_descriptor_ = file->enum_type(6);
-  SYSTEM_V_FCNTL_descriptor_ = file->enum_type(7);
-  REPL_FLAG_descriptor_ = file->enum_type(8);
-  SERVICES_descriptor_ = file->enum_type(9);
+  LeaseState_descriptor_ = file->enum_type(5);
+  PORTS_descriptor_ = file->enum_type(6);
+  CONSTANTS_descriptor_ = file->enum_type(7);
+  SYSTEM_V_FCNTL_descriptor_ = file->enum_type(8);
+  REPL_FLAG_descriptor_ = file->enum_type(9);
+  SERVICES_descriptor_ = file->enum_type(10);
 }
 
 namespace {
@@ -396,30 +398,32 @@ void protobuf_AddDesc_xtreemfs_2fGlobalTypes_2eproto() {
     "LED\020\000\022\036\n\032SNAP_CONFIG_ACCESS_CURRENT\020\001\022\033\n"
     "\027SNAP_CONFIG_ACCESS_SNAP\020\002*P\n\022StripingPo"
     "licyType\022\031\n\025STRIPING_POLICY_RAID0\020\000\022\037\n\033S"
-    "TRIPING_POLICY_ERASURECODE\020\001*\270\001\n\005PORTS\022\033"
-    "\n\025DIR_HTTP_PORT_DEFAULT\020\256\357\001\022\034\n\026DIR_PBRPC"
-    "_PORT_DEFAULT\020\376\376\001\022\033\n\025MRC_HTTP_PORT_DEFAU"
-    "LT\020\254\357\001\022\034\n\026MRC_PBRPC_PORT_DEFAULT\020\374\376\001\022\033\n\025"
-    "OSD_HTTP_PORT_DEFAULT\020\260\357\001\022\034\n\026OSD_PBRPC_P"
-    "ORT_DEFAULT\020\200\377\001*+\n\tCONSTANTS\022\036\n\032XCAP_REN"
-    "EW_INTERVAL_IN_MIN\020\001*\202\003\n\016SYSTEM_V_FCNTL\022"
-    "\035\n\031SYSTEM_V_FCNTL_H_O_RDONLY\020\000\022\035\n\031SYSTEM"
-    "_V_FCNTL_H_O_WRONLY\020\001\022\033\n\027SYSTEM_V_FCNTL_"
-    "H_O_RDWR\020\002\022\035\n\031SYSTEM_V_FCNTL_H_O_APPEND\020"
-    "\010\022\035\n\030SYSTEM_V_FCNTL_H_O_CREAT\020\200\002\022\035\n\030SYST"
-    "EM_V_FCNTL_H_O_TRUNC\020\200\004\022\034\n\027SYSTEM_V_FCNT"
-    "L_H_O_EXCL\020\200\010\022\033\n\027SYSTEM_V_FCNTL_H_O_SYNC"
-    "\020\020\022\036\n\030SYSTEM_V_FCNTL_H_S_IFREG\020\200\200\002\022\036\n\030SY"
-    "STEM_V_FCNTL_H_S_IFDIR\020\200\200\001\022\036\n\030SYSTEM_V_F"
-    "CNTL_H_S_IFLNK\020\200\300\002\022\035\n\030SYSTEM_V_FCNTL_H_S"
-    "_IFIFO\020\200 *\330\001\n\tREPL_FLAG\022\032\n\026REPL_FLAG_FUL"
-    "L_REPLICA\020\001\022\031\n\025REPL_FLAG_IS_COMPLETE\020\002\022\035"
-    "\n\031REPL_FLAG_STRATEGY_RANDOM\020\004\022#\n\037REPL_FL"
-    "AG_STRATEGY_RAREST_FIRST\020\010\022!\n\035REPL_FLAG_"
-    "STRATEGY_SEQUENTIAL\020\020\022-\n)REPL_FLAG_STRAT"
-    "EGY_SEQUENTIAL_PREFETCHING\020 *%\n\010SERVICES"
-    "\022\007\n\003DIR\020\001\022\007\n\003MRC\020\002\022\007\n\003OSD\020\003B(\n&org.xtree"
-    "mfs.pbrpc.generatedinterfaces", 3029);
+    "TRIPING_POLICY_ERASURECODE\020\001*9\n\nLeaseSta"
+    "te\022\010\n\004NONE\020\000\022\013\n\007PRIMARY\020\001\022\n\n\006BACKUP\020\002\022\010\n"
+    "\004IDLE\020\003*\270\001\n\005PORTS\022\033\n\025DIR_HTTP_PORT_DEFAU"
+    "LT\020\256\357\001\022\034\n\026DIR_PBRPC_PORT_DEFAULT\020\376\376\001\022\033\n\025"
+    "MRC_HTTP_PORT_DEFAULT\020\254\357\001\022\034\n\026MRC_PBRPC_P"
+    "ORT_DEFAULT\020\374\376\001\022\033\n\025OSD_HTTP_PORT_DEFAULT"
+    "\020\260\357\001\022\034\n\026OSD_PBRPC_PORT_DEFAULT\020\200\377\001*+\n\tCO"
+    "NSTANTS\022\036\n\032XCAP_RENEW_INTERVAL_IN_MIN\020\001*"
+    "\202\003\n\016SYSTEM_V_FCNTL\022\035\n\031SYSTEM_V_FCNTL_H_O"
+    "_RDONLY\020\000\022\035\n\031SYSTEM_V_FCNTL_H_O_WRONLY\020\001"
+    "\022\033\n\027SYSTEM_V_FCNTL_H_O_RDWR\020\002\022\035\n\031SYSTEM_"
+    "V_FCNTL_H_O_APPEND\020\010\022\035\n\030SYSTEM_V_FCNTL_H"
+    "_O_CREAT\020\200\002\022\035\n\030SYSTEM_V_FCNTL_H_O_TRUNC\020"
+    "\200\004\022\034\n\027SYSTEM_V_FCNTL_H_O_EXCL\020\200\010\022\033\n\027SYST"
+    "EM_V_FCNTL_H_O_SYNC\020\020\022\036\n\030SYSTEM_V_FCNTL_"
+    "H_S_IFREG\020\200\200\002\022\036\n\030SYSTEM_V_FCNTL_H_S_IFDI"
+    "R\020\200\200\001\022\036\n\030SYSTEM_V_FCNTL_H_S_IFLNK\020\200\300\002\022\035\n"
+    "\030SYSTEM_V_FCNTL_H_S_IFIFO\020\200 *\330\001\n\tREPL_FL"
+    "AG\022\032\n\026REPL_FLAG_FULL_REPLICA\020\001\022\031\n\025REPL_F"
+    "LAG_IS_COMPLETE\020\002\022\035\n\031REPL_FLAG_STRATEGY_"
+    "RANDOM\020\004\022#\n\037REPL_FLAG_STRATEGY_RAREST_FI"
+    "RST\020\010\022!\n\035REPL_FLAG_STRATEGY_SEQUENTIAL\020\020"
+    "\022-\n)REPL_FLAG_STRATEGY_SEQUENTIAL_PREFET"
+    "CHING\020 *%\n\010SERVICES\022\007\n\003DIR\020\001\022\007\n\003MRC\020\002\022\007\n"
+    "\003OSD\020\003B(\n&org.xtreemfs.pbrpc.generatedin"
+    "terfaces", 3088);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "xtreemfs/GlobalTypes.proto", &protobuf_RegisterTypes);
   NewFileSize::default_instance_ = new NewFileSize();
@@ -528,6 +532,22 @@ bool StripingPolicyType_IsValid(int value) {
   switch(value) {
     case 0:
     case 1:
+      return true;
+    default:
+      return false;
+  }
+}
+
+const ::google::protobuf::EnumDescriptor* LeaseState_descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return LeaseState_descriptor_;
+}
+bool LeaseState_IsValid(int value) {
+  switch(value) {
+    case 0:
+    case 1:
+    case 2:
+    case 3:
       return true;
     default:
       return false;

--- a/cpp/generated/xtreemfs/GlobalTypes.pb.h
+++ b/cpp/generated/xtreemfs/GlobalTypes.pb.h
@@ -155,6 +155,27 @@ inline bool StripingPolicyType_Parse(
   return ::google::protobuf::internal::ParseNamedEnum<StripingPolicyType>(
     StripingPolicyType_descriptor(), name, value);
 }
+enum LeaseState {
+  NONE = 0,
+  PRIMARY = 1,
+  BACKUP = 2,
+  IDLE = 3
+};
+bool LeaseState_IsValid(int value);
+const LeaseState LeaseState_MIN = NONE;
+const LeaseState LeaseState_MAX = IDLE;
+const int LeaseState_ARRAYSIZE = LeaseState_MAX + 1;
+
+const ::google::protobuf::EnumDescriptor* LeaseState_descriptor();
+inline const ::std::string& LeaseState_Name(LeaseState value) {
+  return ::google::protobuf::internal::NameOfEnum(
+    LeaseState_descriptor(), value);
+}
+inline bool LeaseState_Parse(
+    const ::std::string& name, LeaseState* value) {
+  return ::google::protobuf::internal::ParseNamedEnum<LeaseState>(
+    LeaseState_descriptor(), name, value);
+}
 enum PORTS {
   DIR_HTTP_PORT_DEFAULT = 30638,
   DIR_PBRPC_PORT_DEFAULT = 32638,
@@ -2657,6 +2678,10 @@ inline const EnumDescriptor* GetEnumDescriptor< ::xtreemfs::pbrpc::SnapConfig>()
 template <>
 inline const EnumDescriptor* GetEnumDescriptor< ::xtreemfs::pbrpc::StripingPolicyType>() {
   return ::xtreemfs::pbrpc::StripingPolicyType_descriptor();
+}
+template <>
+inline const EnumDescriptor* GetEnumDescriptor< ::xtreemfs::pbrpc::LeaseState>() {
+  return ::xtreemfs::pbrpc::LeaseState_descriptor();
 }
 template <>
 inline const EnumDescriptor* GetEnumDescriptor< ::xtreemfs::pbrpc::PORTS>() {

--- a/cpp/generated/xtreemfs/OSD.pb.cc
+++ b/cpp/generated/xtreemfs/OSD.pb.cc
@@ -843,8 +843,8 @@ void protobuf_AssignDesc_xtreemfs_2fOSD_2eproto() {
       sizeof(xtreemfs_xloc_set_invalidateRequest));
   xtreemfs_xloc_set_invalidateResponse_descriptor_ = file->message_type(40);
   static const int xtreemfs_xloc_set_invalidateResponse_offsets_[2] = {
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(xtreemfs_xloc_set_invalidateResponse, is_primary_),
-    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(xtreemfs_xloc_set_invalidateResponse, status_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(xtreemfs_xloc_set_invalidateResponse, lease_state_),
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(xtreemfs_xloc_set_invalidateResponse, replica_status_),
   };
   xtreemfs_xloc_set_invalidateResponse_reflection_ =
     new ::google::protobuf::internal::GeneratedMessageReflection(
@@ -1176,111 +1176,112 @@ void protobuf_AddDesc_xtreemfs_2fOSD_2eproto() {
     "\003 \002(\007\"q\n#xtreemfs_xloc_set_invalidateReq"
     "uest\0229\n\020file_credentials\030\001 \002(\0132\037.xtreemf"
     "s.pbrpc.FileCredentials\022\017\n\007file_id\030\002 \002(\t"
-    "\"i\n$xtreemfs_xloc_set_invalidateResponse"
-    "\022\022\n\nis_primary\030\001 \002(\010\022-\n\006status\030\002 \001(\0132\035.x"
-    "treemfs.pbrpc.ReplicaStatus*\215\001\n\017OSDHealt"
-    "hResult\022\034\n\030OSD_HEALTH_RESULT_PASSED\020\000\022\035\n"
-    "\031OSD_HEALTH_RESULT_WARNING\020\001\022\034\n\030OSD_HEAL"
-    "TH_RESULT_FAILED\020\002\022\037\n\033OSD_HEALTH_RESULT_"
-    "NOT_AVAIL\020\0032\277\036\n\nOSDService\022L\n\004read\022\033.xtr"
-    "eemfs.pbrpc.readRequest\032\032.xtreemfs.pbrpc"
-    ".ObjectData\"\013\215\265\030\n\000\000\000\230\265\030\001\022V\n\010truncate\022\037.x"
-    "treemfs.pbrpc.truncateRequest\032 .xtreemfs"
-    ".pbrpc.OSDWriteResponse\"\007\215\265\030\013\000\000\000\022T\n\006unli"
-    "nk\022\".xtreemfs.pbrpc.unlink_osd_Request\032\035"
-    ".xtreemfs.pbrpc.emptyResponse\"\007\215\265\030\014\000\000\000\022T"
-    "\n\005write\022\034.xtreemfs.pbrpc.writeRequest\032 ."
-    "xtreemfs.pbrpc.OSDWriteResponse\"\013\215\265\030\r\000\000\000"
-    "\240\265\030\001\022q\n\027xtreemfs_broadcast_gmax\022..xtreem"
-    "fs.pbrpc.xtreemfs_broadcast_gmaxRequest\032"
-    "\035.xtreemfs.pbrpc.emptyResponse\"\007\215\265\030\024\000\000\000\022"
-    "j\n\025xtreemfs_check_object\022,.xtreemfs.pbrp"
-    "c.xtreemfs_check_objectRequest\032\032.xtreemf"
-    "s.pbrpc.ObjectData\"\007\215\265\030\025\000\000\000\022{\n\034xtreemfs_"
-    "cleanup_get_results\022\034.xtreemfs.pbrpc.emp"
-    "tyRequest\0324.xtreemfs.pbrpc.xtreemfs_clea"
-    "nup_get_resultsResponse\"\007\215\265\030\036\000\000\000\022y\n\033xtre"
-    "emfs_cleanup_is_running\022\034.xtreemfs.pbrpc"
-    ".emptyRequest\0323.xtreemfs.pbrpc.xtreemfs_"
-    "cleanup_is_runningResponse\"\007\215\265\030\037\000\000\000\022o\n\026x"
-    "treemfs_cleanup_start\022-.xtreemfs.pbrpc.x"
-    "treemfs_cleanup_startRequest\032\035.xtreemfs."
-    "pbrpc.emptyResponse\"\007\215\265\030 \000\000\000\022q\n\027xtreemfs"
-    "_cleanup_status\022\034.xtreemfs.pbrpc.emptyRe"
-    "quest\032/.xtreemfs.pbrpc.xtreemfs_cleanup_"
-    "statusResponse\"\007\215\265\030!\000\000\000\022]\n\025xtreemfs_clea"
-    "nup_stop\022\034.xtreemfs.pbrpc.emptyRequest\032\035"
-    ".xtreemfs.pbrpc.emptyResponse\"\007\215\265\030\"\000\000\000\022g"
-    "\n\037xtreemfs_cleanup_versions_start\022\034.xtre"
-    "emfs.pbrpc.emptyRequest\032\035.xtreemfs.pbrpc"
-    ".emptyResponse\"\007\215\265\030#\000\000\000\022o\n\026xtreemfs_repa"
-    "ir_object\022-.xtreemfs.pbrpc.xtreemfs_repa"
-    "ir_objectRequest\032\035.xtreemfs.pbrpc.emptyR"
-    "esponse\"\007\215\265\030$\000\000\000\022d\n\022xtreemfs_rwr_fetch\022)"
-    ".xtreemfs.pbrpc.xtreemfs_rwr_fetchReques"
-    "t\032\032.xtreemfs.pbrpc.ObjectData\"\007\215\265\030I\000\000\000\022u"
-    "\n\027xtreemfs_rwr_flease_msg\022..xtreemfs.pbr"
-    "pc.xtreemfs_rwr_flease_msgRequest\032\035.xtre"
-    "emfs.pbrpc.emptyResponse\"\013\215\265\030G\000\000\000\240\265\030\001\022^\n"
-    "\023xtreemfs_rwr_notify\022\037.xtreemfs.pbrpc.Fi"
-    "leCredentials\032\035.xtreemfs.pbrpc.emptyResp"
-    "onse\"\007\215\265\030K\000\000\000\022|\n\036xtreemfs_rwr_set_primar"
-    "y_epoch\0225.xtreemfs.pbrpc.xtreemfs_rwr_se"
-    "t_primary_epochRequest\032\032.xtreemfs.pbrpc."
-    "ObjectData\"\007\215\265\030N\000\000\000\022i\n\023xtreemfs_rwr_stat"
-    "us\022*.xtreemfs.pbrpc.xtreemfs_rwr_statusR"
-    "equest\032\035.xtreemfs.pbrpc.ReplicaStatus\"\007\215"
-    "\265\030L\000\000\000\022m\n\025xtreemfs_rwr_truncate\022,.xtreem"
-    "fs.pbrpc.xtreemfs_rwr_truncateRequest\032\035."
-    "xtreemfs.pbrpc.emptyResponse\"\007\215\265\030J\000\000\000\022m\n"
-    "\023xtreemfs_rwr_update\022*.xtreemfs.pbrpc.xt"
-    "reemfs_rwr_updateRequest\032\035.xtreemfs.pbrp"
-    "c.emptyResponse\"\013\215\265\030H\000\000\000\240\265\030\001\022q\n\027xtreemfs"
-    "_rwr_auth_state\022..xtreemfs.pbrpc.xtreemf"
-    "s_rwr_auth_stateRequest\032\035.xtreemfs.pbrpc"
-    ".emptyResponse\"\007\215\265\030O\000\000\000\022y\n\033xtreemfs_rwr_"
-    "reset_complete\0222.xtreemfs.pbrpc.xtreemfs"
-    "_rwr_reset_completeRequest\032\035.xtreemfs.pb"
-    "rpc.emptyResponse\"\007\215\265\030P\000\000\000\022v\n\032xtreemfs_i"
-    "nternal_get_gmax\0221.xtreemfs.pbrpc.xtreem"
-    "fs_internal_get_gmaxRequest\032\034.xtreemfs.p"
-    "brpc.InternalGmax\"\007\215\265\030(\000\000\000\022h\n\032xtreemfs_i"
-    "nternal_truncate\022\037.xtreemfs.pbrpc.trunca"
-    "teRequest\032 .xtreemfs.pbrpc.OSDWriteRespo"
-    "nse\"\007\215\265\030)\000\000\000\022\233\001\n\037xtreemfs_internal_get_f"
-    "ile_size\0226.xtreemfs.pbrpc.xtreemfs_inter"
-    "nal_get_file_sizeRequest\0327.xtreemfs.pbrp"
-    "c.xtreemfs_internal_get_file_sizeRespons"
-    "e\"\007\215\265\030*\000\000\000\022\207\001\n\034xtreemfs_internal_read_lo"
-    "cal\0223.xtreemfs.pbrpc.xtreemfs_internal_r"
-    "ead_localRequest\032).xtreemfs.pbrpc.Intern"
-    "alReadLocalResponse\"\007\215\265\030+\000\000\000\022\200\001\n xtreemf"
-    "s_internal_get_object_set\0227.xtreemfs.pbr"
-    "pc.xtreemfs_internal_get_object_setReque"
-    "st\032\032.xtreemfs.pbrpc.ObjectList\"\007\215\265\030,\000\000\000\022"
-    "\205\001\n!xtreemfs_internal_get_fileid_list\022\034."
-    "xtreemfs.pbrpc.emptyRequest\0329.xtreemfs.p"
-    "brpc.xtreemfs_internal_get_fileid_listRe"
-    "sponse\"\007\215\265\030-\000\000\000\022S\n\025xtreemfs_lock_acquire"
-    "\022\033.xtreemfs.pbrpc.lockRequest\032\024.xtreemfs"
-    ".pbrpc.Lock\"\007\215\265\0302\000\000\000\022Q\n\023xtreemfs_lock_ch"
-    "eck\022\033.xtreemfs.pbrpc.lockRequest\032\024.xtree"
-    "mfs.pbrpc.Lock\"\007\215\265\0303\000\000\000\022\\\n\025xtreemfs_lock"
-    "_release\022\033.xtreemfs.pbrpc.lockRequest\032\035."
-    "xtreemfs.pbrpc.emptyResponse\"\007\215\265\0304\000\000\000\022f\n"
-    "\rxtreemfs_ping\022%.xtreemfs.pbrpc.xtreemfs"
-    "_pingMesssage\032%.xtreemfs.pbrpc.xtreemfs_"
-    "pingMesssage\"\007\215\265\030<\000\000\000\022Y\n\021xtreemfs_shutdo"
-    "wn\022\034.xtreemfs.pbrpc.emptyRequest\032\035.xtree"
-    "mfs.pbrpc.emptyResponse\"\007\215\265\030F\000\000\000\022\222\001\n\034xtr"
-    "eemfs_xloc_set_invalidate\0223.xtreemfs.pbr"
-    "pc.xtreemfs_xloc_set_invalidateRequest\0324"
-    ".xtreemfs.pbrpc.xtreemfs_xloc_set_invali"
-    "dateResponse\"\007\215\265\030Q\000\000\000\022}\n#xtreemfs_rwr_au"
-    "th_state_invalidated\022..xtreemfs.pbrpc.xt"
-    "reemfs_rwr_auth_stateRequest\032\035.xtreemfs."
-    "pbrpc.emptyResponse\"\007\215\265\030R\000\000\000\032\007\225\265\0301u\000\000B(\n"
-    "&org.xtreemfs.pbrpc.generatedinterfaces", 9199);
+    "\"\216\001\n$xtreemfs_xloc_set_invalidateRespons"
+    "e\022/\n\013lease_state\030\001 \002(\0162\032.xtreemfs.pbrpc."
+    "LeaseState\0225\n\016replica_status\030\002 \001(\0132\035.xtr"
+    "eemfs.pbrpc.ReplicaStatus*\215\001\n\017OSDHealthR"
+    "esult\022\034\n\030OSD_HEALTH_RESULT_PASSED\020\000\022\035\n\031O"
+    "SD_HEALTH_RESULT_WARNING\020\001\022\034\n\030OSD_HEALTH"
+    "_RESULT_FAILED\020\002\022\037\n\033OSD_HEALTH_RESULT_NO"
+    "T_AVAIL\020\0032\277\036\n\nOSDService\022L\n\004read\022\033.xtree"
+    "mfs.pbrpc.readRequest\032\032.xtreemfs.pbrpc.O"
+    "bjectData\"\013\215\265\030\n\000\000\000\230\265\030\001\022V\n\010truncate\022\037.xtr"
+    "eemfs.pbrpc.truncateRequest\032 .xtreemfs.p"
+    "brpc.OSDWriteResponse\"\007\215\265\030\013\000\000\000\022T\n\006unlink"
+    "\022\".xtreemfs.pbrpc.unlink_osd_Request\032\035.x"
+    "treemfs.pbrpc.emptyResponse\"\007\215\265\030\014\000\000\000\022T\n\005"
+    "write\022\034.xtreemfs.pbrpc.writeRequest\032 .xt"
+    "reemfs.pbrpc.OSDWriteResponse\"\013\215\265\030\r\000\000\000\240\265"
+    "\030\001\022q\n\027xtreemfs_broadcast_gmax\022..xtreemfs"
+    ".pbrpc.xtreemfs_broadcast_gmaxRequest\032\035."
+    "xtreemfs.pbrpc.emptyResponse\"\007\215\265\030\024\000\000\000\022j\n"
+    "\025xtreemfs_check_object\022,.xtreemfs.pbrpc."
+    "xtreemfs_check_objectRequest\032\032.xtreemfs."
+    "pbrpc.ObjectData\"\007\215\265\030\025\000\000\000\022{\n\034xtreemfs_cl"
+    "eanup_get_results\022\034.xtreemfs.pbrpc.empty"
+    "Request\0324.xtreemfs.pbrpc.xtreemfs_cleanu"
+    "p_get_resultsResponse\"\007\215\265\030\036\000\000\000\022y\n\033xtreem"
+    "fs_cleanup_is_running\022\034.xtreemfs.pbrpc.e"
+    "mptyRequest\0323.xtreemfs.pbrpc.xtreemfs_cl"
+    "eanup_is_runningResponse\"\007\215\265\030\037\000\000\000\022o\n\026xtr"
+    "eemfs_cleanup_start\022-.xtreemfs.pbrpc.xtr"
+    "eemfs_cleanup_startRequest\032\035.xtreemfs.pb"
+    "rpc.emptyResponse\"\007\215\265\030 \000\000\000\022q\n\027xtreemfs_c"
+    "leanup_status\022\034.xtreemfs.pbrpc.emptyRequ"
+    "est\032/.xtreemfs.pbrpc.xtreemfs_cleanup_st"
+    "atusResponse\"\007\215\265\030!\000\000\000\022]\n\025xtreemfs_cleanu"
+    "p_stop\022\034.xtreemfs.pbrpc.emptyRequest\032\035.x"
+    "treemfs.pbrpc.emptyResponse\"\007\215\265\030\"\000\000\000\022g\n\037"
+    "xtreemfs_cleanup_versions_start\022\034.xtreem"
+    "fs.pbrpc.emptyRequest\032\035.xtreemfs.pbrpc.e"
+    "mptyResponse\"\007\215\265\030#\000\000\000\022o\n\026xtreemfs_repair"
+    "_object\022-.xtreemfs.pbrpc.xtreemfs_repair"
+    "_objectRequest\032\035.xtreemfs.pbrpc.emptyRes"
+    "ponse\"\007\215\265\030$\000\000\000\022d\n\022xtreemfs_rwr_fetch\022).x"
+    "treemfs.pbrpc.xtreemfs_rwr_fetchRequest\032"
+    "\032.xtreemfs.pbrpc.ObjectData\"\007\215\265\030I\000\000\000\022u\n\027"
+    "xtreemfs_rwr_flease_msg\022..xtreemfs.pbrpc"
+    ".xtreemfs_rwr_flease_msgRequest\032\035.xtreem"
+    "fs.pbrpc.emptyResponse\"\013\215\265\030G\000\000\000\240\265\030\001\022^\n\023x"
+    "treemfs_rwr_notify\022\037.xtreemfs.pbrpc.File"
+    "Credentials\032\035.xtreemfs.pbrpc.emptyRespon"
+    "se\"\007\215\265\030K\000\000\000\022|\n\036xtreemfs_rwr_set_primary_"
+    "epoch\0225.xtreemfs.pbrpc.xtreemfs_rwr_set_"
+    "primary_epochRequest\032\032.xtreemfs.pbrpc.Ob"
+    "jectData\"\007\215\265\030N\000\000\000\022i\n\023xtreemfs_rwr_status"
+    "\022*.xtreemfs.pbrpc.xtreemfs_rwr_statusReq"
+    "uest\032\035.xtreemfs.pbrpc.ReplicaStatus\"\007\215\265\030"
+    "L\000\000\000\022m\n\025xtreemfs_rwr_truncate\022,.xtreemfs"
+    ".pbrpc.xtreemfs_rwr_truncateRequest\032\035.xt"
+    "reemfs.pbrpc.emptyResponse\"\007\215\265\030J\000\000\000\022m\n\023x"
+    "treemfs_rwr_update\022*.xtreemfs.pbrpc.xtre"
+    "emfs_rwr_updateRequest\032\035.xtreemfs.pbrpc."
+    "emptyResponse\"\013\215\265\030H\000\000\000\240\265\030\001\022q\n\027xtreemfs_r"
+    "wr_auth_state\022..xtreemfs.pbrpc.xtreemfs_"
+    "rwr_auth_stateRequest\032\035.xtreemfs.pbrpc.e"
+    "mptyResponse\"\007\215\265\030O\000\000\000\022y\n\033xtreemfs_rwr_re"
+    "set_complete\0222.xtreemfs.pbrpc.xtreemfs_r"
+    "wr_reset_completeRequest\032\035.xtreemfs.pbrp"
+    "c.emptyResponse\"\007\215\265\030P\000\000\000\022v\n\032xtreemfs_int"
+    "ernal_get_gmax\0221.xtreemfs.pbrpc.xtreemfs"
+    "_internal_get_gmaxRequest\032\034.xtreemfs.pbr"
+    "pc.InternalGmax\"\007\215\265\030(\000\000\000\022h\n\032xtreemfs_int"
+    "ernal_truncate\022\037.xtreemfs.pbrpc.truncate"
+    "Request\032 .xtreemfs.pbrpc.OSDWriteRespons"
+    "e\"\007\215\265\030)\000\000\000\022\233\001\n\037xtreemfs_internal_get_fil"
+    "e_size\0226.xtreemfs.pbrpc.xtreemfs_interna"
+    "l_get_file_sizeRequest\0327.xtreemfs.pbrpc."
+    "xtreemfs_internal_get_file_sizeResponse\""
+    "\007\215\265\030*\000\000\000\022\207\001\n\034xtreemfs_internal_read_loca"
+    "l\0223.xtreemfs.pbrpc.xtreemfs_internal_rea"
+    "d_localRequest\032).xtreemfs.pbrpc.Internal"
+    "ReadLocalResponse\"\007\215\265\030+\000\000\000\022\200\001\n xtreemfs_"
+    "internal_get_object_set\0227.xtreemfs.pbrpc"
+    ".xtreemfs_internal_get_object_setRequest"
+    "\032\032.xtreemfs.pbrpc.ObjectList\"\007\215\265\030,\000\000\000\022\205\001"
+    "\n!xtreemfs_internal_get_fileid_list\022\034.xt"
+    "reemfs.pbrpc.emptyRequest\0329.xtreemfs.pbr"
+    "pc.xtreemfs_internal_get_fileid_listResp"
+    "onse\"\007\215\265\030-\000\000\000\022S\n\025xtreemfs_lock_acquire\022\033"
+    ".xtreemfs.pbrpc.lockRequest\032\024.xtreemfs.p"
+    "brpc.Lock\"\007\215\265\0302\000\000\000\022Q\n\023xtreemfs_lock_chec"
+    "k\022\033.xtreemfs.pbrpc.lockRequest\032\024.xtreemf"
+    "s.pbrpc.Lock\"\007\215\265\0303\000\000\000\022\\\n\025xtreemfs_lock_r"
+    "elease\022\033.xtreemfs.pbrpc.lockRequest\032\035.xt"
+    "reemfs.pbrpc.emptyResponse\"\007\215\265\0304\000\000\000\022f\n\rx"
+    "treemfs_ping\022%.xtreemfs.pbrpc.xtreemfs_p"
+    "ingMesssage\032%.xtreemfs.pbrpc.xtreemfs_pi"
+    "ngMesssage\"\007\215\265\030<\000\000\000\022Y\n\021xtreemfs_shutdown"
+    "\022\034.xtreemfs.pbrpc.emptyRequest\032\035.xtreemf"
+    "s.pbrpc.emptyResponse\"\007\215\265\030F\000\000\000\022\222\001\n\034xtree"
+    "mfs_xloc_set_invalidate\0223.xtreemfs.pbrpc"
+    ".xtreemfs_xloc_set_invalidateRequest\0324.x"
+    "treemfs.pbrpc.xtreemfs_xloc_set_invalida"
+    "teResponse\"\007\215\265\030Q\000\000\000\022}\n#xtreemfs_rwr_auth"
+    "_state_invalidated\022..xtreemfs.pbrpc.xtre"
+    "emfs_rwr_auth_stateRequest\032\035.xtreemfs.pb"
+    "rpc.emptyResponse\"\007\215\265\030R\000\000\000\032\007\225\265\0301u\000\000B(\n&o"
+    "rg.xtreemfs.pbrpc.generatedinterfaces", 9237);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "xtreemfs/OSD.proto", &protobuf_RegisterTypes);
   InternalGmax::default_instance_ = new InternalGmax();
@@ -13677,8 +13678,8 @@ void xtreemfs_xloc_set_invalidateRequest::Swap(xtreemfs_xloc_set_invalidateReque
 // ===================================================================
 
 #ifndef _MSC_VER
-const int xtreemfs_xloc_set_invalidateResponse::kIsPrimaryFieldNumber;
-const int xtreemfs_xloc_set_invalidateResponse::kStatusFieldNumber;
+const int xtreemfs_xloc_set_invalidateResponse::kLeaseStateFieldNumber;
+const int xtreemfs_xloc_set_invalidateResponse::kReplicaStatusFieldNumber;
 #endif  // !_MSC_VER
 
 xtreemfs_xloc_set_invalidateResponse::xtreemfs_xloc_set_invalidateResponse()
@@ -13687,7 +13688,7 @@ xtreemfs_xloc_set_invalidateResponse::xtreemfs_xloc_set_invalidateResponse()
 }
 
 void xtreemfs_xloc_set_invalidateResponse::InitAsDefaultInstance() {
-  status_ = const_cast< ::xtreemfs::pbrpc::ReplicaStatus*>(&::xtreemfs::pbrpc::ReplicaStatus::default_instance());
+  replica_status_ = const_cast< ::xtreemfs::pbrpc::ReplicaStatus*>(&::xtreemfs::pbrpc::ReplicaStatus::default_instance());
 }
 
 xtreemfs_xloc_set_invalidateResponse::xtreemfs_xloc_set_invalidateResponse(const xtreemfs_xloc_set_invalidateResponse& from)
@@ -13698,8 +13699,8 @@ xtreemfs_xloc_set_invalidateResponse::xtreemfs_xloc_set_invalidateResponse(const
 
 void xtreemfs_xloc_set_invalidateResponse::SharedCtor() {
   _cached_size_ = 0;
-  is_primary_ = false;
-  status_ = NULL;
+  lease_state_ = 0;
+  replica_status_ = NULL;
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
 }
 
@@ -13709,7 +13710,7 @@ xtreemfs_xloc_set_invalidateResponse::~xtreemfs_xloc_set_invalidateResponse() {
 
 void xtreemfs_xloc_set_invalidateResponse::SharedDtor() {
   if (this != default_instance_) {
-    delete status_;
+    delete replica_status_;
   }
 }
 
@@ -13736,9 +13737,9 @@ xtreemfs_xloc_set_invalidateResponse* xtreemfs_xloc_set_invalidateResponse::New(
 
 void xtreemfs_xloc_set_invalidateResponse::Clear() {
   if (_has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    is_primary_ = false;
-    if (has_status()) {
-      if (status_ != NULL) status_->::xtreemfs::pbrpc::ReplicaStatus::Clear();
+    lease_state_ = 0;
+    if (has_replica_status()) {
+      if (replica_status_ != NULL) replica_status_->::xtreemfs::pbrpc::ReplicaStatus::Clear();
     }
   }
   ::memset(_has_bits_, 0, sizeof(_has_bits_));
@@ -13751,28 +13752,33 @@ bool xtreemfs_xloc_set_invalidateResponse::MergePartialFromCodedStream(
   ::google::protobuf::uint32 tag;
   while ((tag = input->ReadTag()) != 0) {
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // required bool is_primary = 1;
+      // required .xtreemfs.pbrpc.LeaseState lease_state = 1;
       case 1: {
         if (::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
             ::google::protobuf::internal::WireFormatLite::WIRETYPE_VARINT) {
+          int value;
           DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
-                   bool, ::google::protobuf::internal::WireFormatLite::TYPE_BOOL>(
-                 input, &is_primary_)));
-          set_has_is_primary();
+                   int, ::google::protobuf::internal::WireFormatLite::TYPE_ENUM>(
+                 input, &value)));
+          if (::xtreemfs::pbrpc::LeaseState_IsValid(value)) {
+            set_lease_state(static_cast< ::xtreemfs::pbrpc::LeaseState >(value));
+          } else {
+            mutable_unknown_fields()->AddVarint(1, value);
+          }
         } else {
           goto handle_uninterpreted;
         }
-        if (input->ExpectTag(18)) goto parse_status;
+        if (input->ExpectTag(18)) goto parse_replica_status;
         break;
       }
 
-      // optional .xtreemfs.pbrpc.ReplicaStatus status = 2;
+      // optional .xtreemfs.pbrpc.ReplicaStatus replica_status = 2;
       case 2: {
         if (::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
             ::google::protobuf::internal::WireFormatLite::WIRETYPE_LENGTH_DELIMITED) {
-         parse_status:
+         parse_replica_status:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_status()));
+               input, mutable_replica_status()));
         } else {
           goto handle_uninterpreted;
         }
@@ -13798,15 +13804,16 @@ bool xtreemfs_xloc_set_invalidateResponse::MergePartialFromCodedStream(
 
 void xtreemfs_xloc_set_invalidateResponse::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
-  // required bool is_primary = 1;
-  if (has_is_primary()) {
-    ::google::protobuf::internal::WireFormatLite::WriteBool(1, this->is_primary(), output);
+  // required .xtreemfs.pbrpc.LeaseState lease_state = 1;
+  if (has_lease_state()) {
+    ::google::protobuf::internal::WireFormatLite::WriteEnum(
+      1, this->lease_state(), output);
   }
 
-  // optional .xtreemfs.pbrpc.ReplicaStatus status = 2;
-  if (has_status()) {
+  // optional .xtreemfs.pbrpc.ReplicaStatus replica_status = 2;
+  if (has_replica_status()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      2, this->status(), output);
+      2, this->replica_status(), output);
   }
 
   if (!unknown_fields().empty()) {
@@ -13817,16 +13824,17 @@ void xtreemfs_xloc_set_invalidateResponse::SerializeWithCachedSizes(
 
 ::google::protobuf::uint8* xtreemfs_xloc_set_invalidateResponse::SerializeWithCachedSizesToArray(
     ::google::protobuf::uint8* target) const {
-  // required bool is_primary = 1;
-  if (has_is_primary()) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteBoolToArray(1, this->is_primary(), target);
+  // required .xtreemfs.pbrpc.LeaseState lease_state = 1;
+  if (has_lease_state()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteEnumToArray(
+      1, this->lease_state(), target);
   }
 
-  // optional .xtreemfs.pbrpc.ReplicaStatus status = 2;
-  if (has_status()) {
+  // optional .xtreemfs.pbrpc.ReplicaStatus replica_status = 2;
+  if (has_replica_status()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        2, this->status(), target);
+        2, this->replica_status(), target);
   }
 
   if (!unknown_fields().empty()) {
@@ -13840,16 +13848,17 @@ int xtreemfs_xloc_set_invalidateResponse::ByteSize() const {
   int total_size = 0;
 
   if (_has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    // required bool is_primary = 1;
-    if (has_is_primary()) {
-      total_size += 1 + 1;
+    // required .xtreemfs.pbrpc.LeaseState lease_state = 1;
+    if (has_lease_state()) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::EnumSize(this->lease_state());
     }
 
-    // optional .xtreemfs.pbrpc.ReplicaStatus status = 2;
-    if (has_status()) {
+    // optional .xtreemfs.pbrpc.ReplicaStatus replica_status = 2;
+    if (has_replica_status()) {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          this->status());
+          this->replica_status());
     }
 
   }
@@ -13879,11 +13888,11 @@ void xtreemfs_xloc_set_invalidateResponse::MergeFrom(const ::google::protobuf::M
 void xtreemfs_xloc_set_invalidateResponse::MergeFrom(const xtreemfs_xloc_set_invalidateResponse& from) {
   GOOGLE_CHECK_NE(&from, this);
   if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
-    if (from.has_is_primary()) {
-      set_is_primary(from.is_primary());
+    if (from.has_lease_state()) {
+      set_lease_state(from.lease_state());
     }
-    if (from.has_status()) {
-      mutable_status()->::xtreemfs::pbrpc::ReplicaStatus::MergeFrom(from.status());
+    if (from.has_replica_status()) {
+      mutable_replica_status()->::xtreemfs::pbrpc::ReplicaStatus::MergeFrom(from.replica_status());
     }
   }
   mutable_unknown_fields()->MergeFrom(from.unknown_fields());
@@ -13904,16 +13913,16 @@ void xtreemfs_xloc_set_invalidateResponse::CopyFrom(const xtreemfs_xloc_set_inva
 bool xtreemfs_xloc_set_invalidateResponse::IsInitialized() const {
   if ((_has_bits_[0] & 0x00000001) != 0x00000001) return false;
 
-  if (has_status()) {
-    if (!this->status().IsInitialized()) return false;
+  if (has_replica_status()) {
+    if (!this->replica_status().IsInitialized()) return false;
   }
   return true;
 }
 
 void xtreemfs_xloc_set_invalidateResponse::Swap(xtreemfs_xloc_set_invalidateResponse* other) {
   if (other != this) {
-    std::swap(is_primary_, other->is_primary_);
-    std::swap(status_, other->status_);
+    std::swap(lease_state_, other->lease_state_);
+    std::swap(replica_status_, other->replica_status_);
     std::swap(_has_bits_[0], other->_has_bits_[0]);
     _unknown_fields_.Swap(&other->_unknown_fields_);
     std::swap(_cached_size_, other->_cached_size_);

--- a/cpp/generated/xtreemfs/OSD.pb.h
+++ b/cpp/generated/xtreemfs/OSD.pb.h
@@ -4502,33 +4502,33 @@ class xtreemfs_xloc_set_invalidateResponse : public ::google::protobuf::Message 
 
   // accessors -------------------------------------------------------
 
-  // required bool is_primary = 1;
-  inline bool has_is_primary() const;
-  inline void clear_is_primary();
-  static const int kIsPrimaryFieldNumber = 1;
-  inline bool is_primary() const;
-  inline void set_is_primary(bool value);
+  // required .xtreemfs.pbrpc.LeaseState lease_state = 1;
+  inline bool has_lease_state() const;
+  inline void clear_lease_state();
+  static const int kLeaseStateFieldNumber = 1;
+  inline ::xtreemfs::pbrpc::LeaseState lease_state() const;
+  inline void set_lease_state(::xtreemfs::pbrpc::LeaseState value);
 
-  // optional .xtreemfs.pbrpc.ReplicaStatus status = 2;
-  inline bool has_status() const;
-  inline void clear_status();
-  static const int kStatusFieldNumber = 2;
-  inline const ::xtreemfs::pbrpc::ReplicaStatus& status() const;
-  inline ::xtreemfs::pbrpc::ReplicaStatus* mutable_status();
-  inline ::xtreemfs::pbrpc::ReplicaStatus* release_status();
-  inline void set_allocated_status(::xtreemfs::pbrpc::ReplicaStatus* status);
+  // optional .xtreemfs.pbrpc.ReplicaStatus replica_status = 2;
+  inline bool has_replica_status() const;
+  inline void clear_replica_status();
+  static const int kReplicaStatusFieldNumber = 2;
+  inline const ::xtreemfs::pbrpc::ReplicaStatus& replica_status() const;
+  inline ::xtreemfs::pbrpc::ReplicaStatus* mutable_replica_status();
+  inline ::xtreemfs::pbrpc::ReplicaStatus* release_replica_status();
+  inline void set_allocated_replica_status(::xtreemfs::pbrpc::ReplicaStatus* replica_status);
 
   // @@protoc_insertion_point(class_scope:xtreemfs.pbrpc.xtreemfs_xloc_set_invalidateResponse)
  private:
-  inline void set_has_is_primary();
-  inline void clear_has_is_primary();
-  inline void set_has_status();
-  inline void clear_has_status();
+  inline void set_has_lease_state();
+  inline void clear_has_lease_state();
+  inline void set_has_replica_status();
+  inline void clear_has_replica_status();
 
   ::google::protobuf::UnknownFieldSet _unknown_fields_;
 
-  ::xtreemfs::pbrpc::ReplicaStatus* status_;
-  bool is_primary_;
+  ::xtreemfs::pbrpc::ReplicaStatus* replica_status_;
+  int lease_state_;
 
   mutable int _cached_size_;
   ::google::protobuf::uint32 _has_bits_[(2 + 31) / 32];
@@ -9096,63 +9096,64 @@ inline void xtreemfs_xloc_set_invalidateRequest::set_allocated_file_id(::std::st
 
 // xtreemfs_xloc_set_invalidateResponse
 
-// required bool is_primary = 1;
-inline bool xtreemfs_xloc_set_invalidateResponse::has_is_primary() const {
+// required .xtreemfs.pbrpc.LeaseState lease_state = 1;
+inline bool xtreemfs_xloc_set_invalidateResponse::has_lease_state() const {
   return (_has_bits_[0] & 0x00000001u) != 0;
 }
-inline void xtreemfs_xloc_set_invalidateResponse::set_has_is_primary() {
+inline void xtreemfs_xloc_set_invalidateResponse::set_has_lease_state() {
   _has_bits_[0] |= 0x00000001u;
 }
-inline void xtreemfs_xloc_set_invalidateResponse::clear_has_is_primary() {
+inline void xtreemfs_xloc_set_invalidateResponse::clear_has_lease_state() {
   _has_bits_[0] &= ~0x00000001u;
 }
-inline void xtreemfs_xloc_set_invalidateResponse::clear_is_primary() {
-  is_primary_ = false;
-  clear_has_is_primary();
+inline void xtreemfs_xloc_set_invalidateResponse::clear_lease_state() {
+  lease_state_ = 0;
+  clear_has_lease_state();
 }
-inline bool xtreemfs_xloc_set_invalidateResponse::is_primary() const {
-  return is_primary_;
+inline ::xtreemfs::pbrpc::LeaseState xtreemfs_xloc_set_invalidateResponse::lease_state() const {
+  return static_cast< ::xtreemfs::pbrpc::LeaseState >(lease_state_);
 }
-inline void xtreemfs_xloc_set_invalidateResponse::set_is_primary(bool value) {
-  set_has_is_primary();
-  is_primary_ = value;
+inline void xtreemfs_xloc_set_invalidateResponse::set_lease_state(::xtreemfs::pbrpc::LeaseState value) {
+  assert(::xtreemfs::pbrpc::LeaseState_IsValid(value));
+  set_has_lease_state();
+  lease_state_ = value;
 }
 
-// optional .xtreemfs.pbrpc.ReplicaStatus status = 2;
-inline bool xtreemfs_xloc_set_invalidateResponse::has_status() const {
+// optional .xtreemfs.pbrpc.ReplicaStatus replica_status = 2;
+inline bool xtreemfs_xloc_set_invalidateResponse::has_replica_status() const {
   return (_has_bits_[0] & 0x00000002u) != 0;
 }
-inline void xtreemfs_xloc_set_invalidateResponse::set_has_status() {
+inline void xtreemfs_xloc_set_invalidateResponse::set_has_replica_status() {
   _has_bits_[0] |= 0x00000002u;
 }
-inline void xtreemfs_xloc_set_invalidateResponse::clear_has_status() {
+inline void xtreemfs_xloc_set_invalidateResponse::clear_has_replica_status() {
   _has_bits_[0] &= ~0x00000002u;
 }
-inline void xtreemfs_xloc_set_invalidateResponse::clear_status() {
-  if (status_ != NULL) status_->::xtreemfs::pbrpc::ReplicaStatus::Clear();
-  clear_has_status();
+inline void xtreemfs_xloc_set_invalidateResponse::clear_replica_status() {
+  if (replica_status_ != NULL) replica_status_->::xtreemfs::pbrpc::ReplicaStatus::Clear();
+  clear_has_replica_status();
 }
-inline const ::xtreemfs::pbrpc::ReplicaStatus& xtreemfs_xloc_set_invalidateResponse::status() const {
-  return status_ != NULL ? *status_ : *default_instance_->status_;
+inline const ::xtreemfs::pbrpc::ReplicaStatus& xtreemfs_xloc_set_invalidateResponse::replica_status() const {
+  return replica_status_ != NULL ? *replica_status_ : *default_instance_->replica_status_;
 }
-inline ::xtreemfs::pbrpc::ReplicaStatus* xtreemfs_xloc_set_invalidateResponse::mutable_status() {
-  set_has_status();
-  if (status_ == NULL) status_ = new ::xtreemfs::pbrpc::ReplicaStatus;
-  return status_;
+inline ::xtreemfs::pbrpc::ReplicaStatus* xtreemfs_xloc_set_invalidateResponse::mutable_replica_status() {
+  set_has_replica_status();
+  if (replica_status_ == NULL) replica_status_ = new ::xtreemfs::pbrpc::ReplicaStatus;
+  return replica_status_;
 }
-inline ::xtreemfs::pbrpc::ReplicaStatus* xtreemfs_xloc_set_invalidateResponse::release_status() {
-  clear_has_status();
-  ::xtreemfs::pbrpc::ReplicaStatus* temp = status_;
-  status_ = NULL;
+inline ::xtreemfs::pbrpc::ReplicaStatus* xtreemfs_xloc_set_invalidateResponse::release_replica_status() {
+  clear_has_replica_status();
+  ::xtreemfs::pbrpc::ReplicaStatus* temp = replica_status_;
+  replica_status_ = NULL;
   return temp;
 }
-inline void xtreemfs_xloc_set_invalidateResponse::set_allocated_status(::xtreemfs::pbrpc::ReplicaStatus* status) {
-  delete status_;
-  status_ = status;
-  if (status) {
-    set_has_status();
+inline void xtreemfs_xloc_set_invalidateResponse::set_allocated_replica_status(::xtreemfs::pbrpc::ReplicaStatus* replica_status) {
+  delete replica_status_;
+  replica_status_ = replica_status;
+  if (replica_status) {
+    set_has_replica_status();
   } else {
-    clear_has_status();
+    clear_has_replica_status();
   }
 }
 

--- a/interface/xtreemfs/GlobalTypes.proto
+++ b/interface/xtreemfs/GlobalTypes.proto
@@ -127,7 +127,7 @@ message Replica {
     // Length of this list must be equal to width
     // in striping_policy!
     repeated string osd_uuids = 1;
-    // Flags to conrol replication, e.g. transfer strategy.
+    // Flags to control replication, e.g. transfer strategy.
     required fixed32 replication_flags = 2;
     // Striping policy for this replica.
     required StripingPolicy striping_policy = 3;
@@ -136,6 +136,18 @@ message Replica {
 // List of replicas for a file.
 message Replicas {
   repeated Replica replicas = 1;
+}
+
+// The LeaseState for a Replica.
+enum LeaseState {
+  // The replica's update policy is not using lease.
+  NONE = 0;
+  // The replica is the the primary.
+  PRIMARY = 1;
+  // The replica is a backup (and an active primary exists).
+  BACKUP = 2;
+  // The replica is not active (currently no lease exists).
+  IDLE = 3;
 }
 
 // The XCap is the authorization token that allows a 

--- a/interface/xtreemfs/OSD.proto
+++ b/interface/xtreemfs/OSD.proto
@@ -354,8 +354,19 @@ message xtreemfs_xloc_set_invalidateRequest {
 }
 
 message xtreemfs_xloc_set_invalidateResponse {
-  required bool is_primary = 1;
-  optional ReplicaStatus status = 2;
+  enum LeaseState {
+    // The replica doesn't use lease, or an error occured.
+    NONE = 0;
+    // The replica has been the primary.
+    PRIMARY = 1;
+    // The replica has been a backup with an active primary.
+    BACKUP = 2;
+    // The replica is not active/opened.
+    IDLE = 3;
+  };
+
+  required LeaseState lease_state = 1;
+  optional ReplicaStatus replica_status = 2;
 }
 
 // Status of OSD health test

--- a/interface/xtreemfs/OSD.proto
+++ b/interface/xtreemfs/OSD.proto
@@ -354,17 +354,6 @@ message xtreemfs_xloc_set_invalidateRequest {
 }
 
 message xtreemfs_xloc_set_invalidateResponse {
-  enum LeaseState {
-    // The replica doesn't use lease, or an error occured.
-    NONE = 0;
-    // The replica has been the primary.
-    PRIMARY = 1;
-    // The replica has been a backup with an active primary.
-    BACKUP = 2;
-    // The replica is not active/opened.
-    IDLE = 3;
-  };
-
   required LeaseState lease_state = 1;
   optional ReplicaStatus replica_status = 2;
 }

--- a/java/servers/src/org/xtreemfs/mrc/stages/XLocSetCoordinator.java
+++ b/java/servers/src/org/xtreemfs/mrc/stages/XLocSetCoordinator.java
@@ -51,6 +51,7 @@ import org.xtreemfs.mrc.utils.Converter;
 import org.xtreemfs.osd.rwre.CoordinatedReplicaUpdatePolicy;
 import org.xtreemfs.pbrpc.generatedinterfaces.Common.emptyResponse;
 import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.FileCredentials;
+import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.LeaseState;
 import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.SnapConfig;
 import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.XLocSet;
 import org.xtreemfs.pbrpc.generatedinterfaces.OSD.AuthoritativeReplicaState;
@@ -58,7 +59,6 @@ import org.xtreemfs.pbrpc.generatedinterfaces.OSD.ObjectVersionMapping;
 import org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus;
 import org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_rwr_auth_stateRequest;
 import org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_xloc_set_invalidateResponse;
-import org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_xloc_set_invalidateResponse.LeaseState;
 import org.xtreemfs.pbrpc.generatedinterfaces.OSDServiceClient;
 
 /**

--- a/java/servers/src/org/xtreemfs/osd/operations/InternalRWRAuthStateInvalidatedOperation.java
+++ b/java/servers/src/org/xtreemfs/osd/operations/InternalRWRAuthStateInvalidatedOperation.java
@@ -23,6 +23,7 @@ import org.xtreemfs.osd.stages.StorageStage.InternalGetReplicaStateCallback;
 import org.xtreemfs.pbrpc.generatedinterfaces.Common.emptyResponse;
 import org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus;
 import org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_rwr_auth_stateRequest;
+import org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_xloc_set_invalidateResponse.LeaseState;
 import org.xtreemfs.pbrpc.generatedinterfaces.OSDServiceConstants;
 
 /**
@@ -55,7 +56,7 @@ public class InternalRWRAuthStateInvalidatedOperation extends OSDOperation {
                 new InvalidateXLocSetCallback() {
 
                     @Override
-                    public void invalidateComplete(boolean isPrimary, ErrorResponse error) {
+                    public void invalidateComplete(LeaseState leaseState, ErrorResponse error) {
                         if (error != null) {
                             rq.sendError(error);
                         } else {

--- a/java/servers/src/org/xtreemfs/osd/operations/InternalRWRAuthStateInvalidatedOperation.java
+++ b/java/servers/src/org/xtreemfs/osd/operations/InternalRWRAuthStateInvalidatedOperation.java
@@ -21,9 +21,9 @@ import org.xtreemfs.osd.rwre.RWReplicationStage.RWReplicationCallback;
 import org.xtreemfs.osd.stages.PreprocStage.InvalidateXLocSetCallback;
 import org.xtreemfs.osd.stages.StorageStage.InternalGetReplicaStateCallback;
 import org.xtreemfs.pbrpc.generatedinterfaces.Common.emptyResponse;
+import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.LeaseState;
 import org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus;
 import org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_rwr_auth_stateRequest;
-import org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_xloc_set_invalidateResponse.LeaseState;
 import org.xtreemfs.pbrpc.generatedinterfaces.OSDServiceConstants;
 
 /**

--- a/java/servers/src/org/xtreemfs/osd/operations/InvalidateXLocSetOperation.java
+++ b/java/servers/src/org/xtreemfs/osd/operations/InvalidateXLocSetOperation.java
@@ -22,10 +22,10 @@ import org.xtreemfs.osd.OSDRequest;
 import org.xtreemfs.osd.OSDRequestDispatcher;
 import org.xtreemfs.osd.stages.PreprocStage.InvalidateXLocSetCallback;
 import org.xtreemfs.osd.stages.StorageStage.InternalGetReplicaStateCallback;
+import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.LeaseState;
 import org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus;
 import org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_xloc_set_invalidateRequest;
 import org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_xloc_set_invalidateResponse;
-import org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_xloc_set_invalidateResponse.LeaseState;
 import org.xtreemfs.pbrpc.generatedinterfaces.OSDServiceConstants;
 
 /**

--- a/java/servers/src/org/xtreemfs/osd/operations/InvalidateXLocSetOperation.java
+++ b/java/servers/src/org/xtreemfs/osd/operations/InvalidateXLocSetOperation.java
@@ -25,6 +25,7 @@ import org.xtreemfs.osd.stages.StorageStage.InternalGetReplicaStateCallback;
 import org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus;
 import org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_xloc_set_invalidateRequest;
 import org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_xloc_set_invalidateResponse;
+import org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_xloc_set_invalidateResponse.LeaseState;
 import org.xtreemfs.pbrpc.generatedinterfaces.OSDServiceConstants;
 
 /**
@@ -57,19 +58,19 @@ public class InvalidateXLocSetOperation extends OSDOperation {
                 new InvalidateXLocSetCallback() {
 
                     @Override
-                    public void invalidateComplete(boolean isPrimary, ErrorResponse error) {
+                    public void invalidateComplete(LeaseState leaseState, ErrorResponse error) {
                         if (error != null) {
                             rq.sendError(error);
                         } else {
-                            postInvalidation(rq, isPrimary);
+                            postInvalidation(rq, leaseState);
                         }
                     }
                 });
     }
 
-    private void postInvalidation(final OSDRequest rq, final boolean isPrimary) {
+    private void postInvalidation(final OSDRequest rq, final LeaseState leaseState) {
         if (rq.getLocationList().getReplicaUpdatePolicy().equals(ReplicaUpdatePolicies.REPL_UPDATE_PC_RONLY)) {
-            invalidationFinished(rq, isPrimary, null);
+            invalidationFinished(rq, leaseState, null);
         } else {
             master.getStorageStage().internalGetReplicaState(rq.getFileId(),
                     rq.getLocationList().getLocalReplica().getStripingPolicy(), 0,
@@ -80,19 +81,19 @@ public class InvalidateXLocSetOperation extends OSDOperation {
                             if (error != null) {
                                 rq.sendError(error);
                             } else {
-                                invalidationFinished(rq, isPrimary, localState);
+                                invalidationFinished(rq, leaseState, localState);
                             }
                         }
                     });
         }
     }
 
-    private void invalidationFinished(OSDRequest rq, boolean isPrimary, ReplicaStatus localState) {
+    private void invalidationFinished(OSDRequest rq, LeaseState leaseState, ReplicaStatus localState) {
         xtreemfs_xloc_set_invalidateResponse.Builder response = xtreemfs_xloc_set_invalidateResponse.newBuilder();
-        response.setIsPrimary(isPrimary);
+        response.setLeaseState(leaseState);
 
         if (localState != null) {
-            response.setStatus(localState);
+            response.setReplicaStatus(localState);
         }
         
         rq.sendSuccess(response.build(), null);

--- a/java/servers/src/org/xtreemfs/osd/rwre/RWReplicationStage.java
+++ b/java/servers/src/org/xtreemfs/osd/rwre/RWReplicationStage.java
@@ -59,6 +59,7 @@ import org.xtreemfs.osd.stages.StorageStage.InternalGetMaxObjectNoCallback;
 import org.xtreemfs.osd.stages.StorageStage.WriteObjectCallback;
 import org.xtreemfs.osd.storage.CowPolicy;
 import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.FileCredentials;
+import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.LeaseState;
 import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.OSDWriteResponse;
 import org.xtreemfs.pbrpc.generatedinterfaces.OSD.AuthoritativeReplicaState;
 import org.xtreemfs.pbrpc.generatedinterfaces.OSD.ObjectData;
@@ -66,7 +67,6 @@ import org.xtreemfs.pbrpc.generatedinterfaces.OSD.ObjectVersion;
 import org.xtreemfs.pbrpc.generatedinterfaces.OSD.ObjectVersionMapping;
 import org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus;
 import org.xtreemfs.pbrpc.generatedinterfaces.OSD.XLocSetVersionState;
-import org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_xloc_set_invalidateResponse.LeaseState;
 import org.xtreemfs.pbrpc.generatedinterfaces.OSDServiceClient;
 
 /**

--- a/java/servers/src/org/xtreemfs/osd/stages/PreprocStage.java
+++ b/java/servers/src/org/xtreemfs/osd/stages/PreprocStage.java
@@ -45,11 +45,11 @@ import org.xtreemfs.osd.storage.CowPolicy.cowMode;
 import org.xtreemfs.osd.storage.MetadataCache;
 import org.xtreemfs.osd.storage.StorageLayout;
 import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.FileCredentials;
+import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.LeaseState;
 import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.SYSTEM_V_FCNTL;
 import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.SnapConfig;
 import org.xtreemfs.pbrpc.generatedinterfaces.OSD.Lock;
 import org.xtreemfs.pbrpc.generatedinterfaces.OSD.XLocSetVersionState;
-import org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_xloc_set_invalidateResponse.LeaseState;
 import org.xtreemfs.pbrpc.generatedinterfaces.OSDServiceConstants;
 
 import com.google.protobuf.Message;

--- a/java/servers/src/org/xtreemfs/osd/stages/PreprocStage.java
+++ b/java/servers/src/org/xtreemfs/osd/stages/PreprocStage.java
@@ -49,6 +49,7 @@ import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.SYSTEM_V_FCNTL;
 import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.SnapConfig;
 import org.xtreemfs.pbrpc.generatedinterfaces.OSD.Lock;
 import org.xtreemfs.pbrpc.generatedinterfaces.OSD.XLocSetVersionState;
+import org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_xloc_set_invalidateResponse.LeaseState;
 import org.xtreemfs.pbrpc.generatedinterfaces.OSDServiceConstants;
 
 import com.google.protobuf.Message;
@@ -819,24 +820,24 @@ public class PreprocStage extends Stage {
             if (xLoc.getNumReplicas() > 1 && ReplicaUpdatePolicies.isRwReplicated(xLoc.getReplicaUpdatePolicy())) {
                 master.getRWReplicationStage().invalidateReplica(fileId, fileCreds, xLoc, callback);
             } else {
-                callback.invalidateComplete(true, null);
+                callback.invalidateComplete(LeaseState.NONE, null);
             }
 
         } catch (InvalidXLocationsException e) {
             ErrorResponse error = ErrorUtils.getErrorResponse(ErrorType.INVALID_VIEW, POSIXErrno.POSIX_ERROR_NONE,
                     e.getMessage(), e);
-            callback.invalidateComplete(false, error);
+            callback.invalidateComplete(LeaseState.NONE, error);
         } catch (IOException e) {
             Logging.logMessage(Logging.LEVEL_ERROR, Category.storage, this,
                     "VersionState could not be written for fileId: %s", fileId);
             ErrorResponse error = ErrorUtils.getErrorResponse(ErrorType.ERRNO, POSIXErrno.POSIX_ERROR_EIO,
                     "Invalid view. Local version could not be written.");
-            callback.invalidateComplete(false, error);
+            callback.invalidateComplete(LeaseState.NONE, error);
         }
     }
 
     public static interface InvalidateXLocSetCallback {
-        public void invalidateComplete(boolean isPrimary, ErrorResponse error);
+        public void invalidateComplete(LeaseState leaseState, ErrorResponse error);
     }
 
     public int getNumOpenFiles() {

--- a/java/servers/src/org/xtreemfs/pbrpc/generatedinterfaces/GlobalTypes.java
+++ b/java/servers/src/org/xtreemfs/pbrpc/generatedinterfaces/GlobalTypes.java
@@ -702,6 +702,142 @@ public final class GlobalTypes {
   }
 
   /**
+   * Protobuf enum {@code xtreemfs.pbrpc.LeaseState}
+   *
+   * <pre>
+   * The LeaseState for a Replica.
+   * </pre>
+   */
+  public enum LeaseState
+      implements com.google.protobuf.ProtocolMessageEnum {
+    /**
+     * <code>NONE = 0;</code>
+     *
+     * <pre>
+     * The replica's update policy is not using lease.
+     * </pre>
+     */
+    NONE(0, 0),
+    /**
+     * <code>PRIMARY = 1;</code>
+     *
+     * <pre>
+     * The replica is the the primary.
+     * </pre>
+     */
+    PRIMARY(1, 1),
+    /**
+     * <code>BACKUP = 2;</code>
+     *
+     * <pre>
+     * The replica is a backup (and an active primary exists).
+     * </pre>
+     */
+    BACKUP(2, 2),
+    /**
+     * <code>IDLE = 3;</code>
+     *
+     * <pre>
+     * The replica is not active (currently no lease exists).
+     * </pre>
+     */
+    IDLE(3, 3),
+    ;
+
+    /**
+     * <code>NONE = 0;</code>
+     *
+     * <pre>
+     * The replica's update policy is not using lease.
+     * </pre>
+     */
+    public static final int NONE_VALUE = 0;
+    /**
+     * <code>PRIMARY = 1;</code>
+     *
+     * <pre>
+     * The replica is the the primary.
+     * </pre>
+     */
+    public static final int PRIMARY_VALUE = 1;
+    /**
+     * <code>BACKUP = 2;</code>
+     *
+     * <pre>
+     * The replica is a backup (and an active primary exists).
+     * </pre>
+     */
+    public static final int BACKUP_VALUE = 2;
+    /**
+     * <code>IDLE = 3;</code>
+     *
+     * <pre>
+     * The replica is not active (currently no lease exists).
+     * </pre>
+     */
+    public static final int IDLE_VALUE = 3;
+
+
+    public final int getNumber() { return value; }
+
+    public static LeaseState valueOf(int value) {
+      switch (value) {
+        case 0: return NONE;
+        case 1: return PRIMARY;
+        case 2: return BACKUP;
+        case 3: return IDLE;
+        default: return null;
+      }
+    }
+
+    public static com.google.protobuf.Internal.EnumLiteMap<LeaseState>
+        internalGetValueMap() {
+      return internalValueMap;
+    }
+    private static com.google.protobuf.Internal.EnumLiteMap<LeaseState>
+        internalValueMap =
+          new com.google.protobuf.Internal.EnumLiteMap<LeaseState>() {
+            public LeaseState findValueByNumber(int number) {
+              return LeaseState.valueOf(number);
+            }
+          };
+
+    public final com.google.protobuf.Descriptors.EnumValueDescriptor
+        getValueDescriptor() {
+      return getDescriptor().getValues().get(index);
+    }
+    public final com.google.protobuf.Descriptors.EnumDescriptor
+        getDescriptorForType() {
+      return getDescriptor();
+    }
+    public static final com.google.protobuf.Descriptors.EnumDescriptor
+        getDescriptor() {
+      return org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.getDescriptor().getEnumTypes().get(5);
+    }
+
+    private static final LeaseState[] VALUES = values();
+
+    public static LeaseState valueOf(
+        com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
+      if (desc.getType() != getDescriptor()) {
+        throw new java.lang.IllegalArgumentException(
+          "EnumValueDescriptor is not for this type.");
+      }
+      return VALUES[desc.getIndex()];
+    }
+
+    private final int index;
+    private final int value;
+
+    private LeaseState(int index, int value) {
+      this.index = index;
+      this.value = value;
+    }
+
+    // @@protoc_insertion_point(enum_scope:xtreemfs.pbrpc.LeaseState)
+  }
+
+  /**
    * Protobuf enum {@code xtreemfs.pbrpc.PORTS}
    *
    * <pre>
@@ -799,7 +935,7 @@ public final class GlobalTypes {
     }
     public static final com.google.protobuf.Descriptors.EnumDescriptor
         getDescriptor() {
-      return org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.getDescriptor().getEnumTypes().get(5);
+      return org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.getDescriptor().getEnumTypes().get(6);
     }
 
     private static final PORTS[] VALUES = values();
@@ -876,7 +1012,7 @@ public final class GlobalTypes {
     }
     public static final com.google.protobuf.Descriptors.EnumDescriptor
         getDescriptor() {
-      return org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.getDescriptor().getEnumTypes().get(6);
+      return org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.getDescriptor().getEnumTypes().get(7);
     }
 
     private static final CONSTANTS[] VALUES = values();
@@ -1053,7 +1189,7 @@ public final class GlobalTypes {
     }
     public static final com.google.protobuf.Descriptors.EnumDescriptor
         getDescriptor() {
-      return org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.getDescriptor().getEnumTypes().get(7);
+      return org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.getDescriptor().getEnumTypes().get(8);
     }
 
     private static final SYSTEM_V_FCNTL[] VALUES = values();
@@ -1176,7 +1312,7 @@ public final class GlobalTypes {
     }
     public static final com.google.protobuf.Descriptors.EnumDescriptor
         getDescriptor() {
-      return org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.getDescriptor().getEnumTypes().get(8);
+      return org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.getDescriptor().getEnumTypes().get(9);
     }
 
     private static final REPL_FLAG[] VALUES = values();
@@ -1267,7 +1403,7 @@ public final class GlobalTypes {
     }
     public static final com.google.protobuf.Descriptors.EnumDescriptor
         getDescriptor() {
-      return org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.getDescriptor().getEnumTypes().get(9);
+      return org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.getDescriptor().getEnumTypes().get(10);
     }
 
     private static final SERVICES[] VALUES = values();
@@ -2725,7 +2861,7 @@ public final class GlobalTypes {
      * <code>required fixed32 replication_flags = 2;</code>
      *
      * <pre>
-     * Flags to conrol replication, e.g. transfer strategy.
+     * Flags to control replication, e.g. transfer strategy.
      * </pre>
      */
     boolean hasReplicationFlags();
@@ -2733,7 +2869,7 @@ public final class GlobalTypes {
      * <code>required fixed32 replication_flags = 2;</code>
      *
      * <pre>
-     * Flags to conrol replication, e.g. transfer strategy.
+     * Flags to control replication, e.g. transfer strategy.
      * </pre>
      */
     int getReplicationFlags();
@@ -2949,7 +3085,7 @@ public final class GlobalTypes {
      * <code>required fixed32 replication_flags = 2;</code>
      *
      * <pre>
-     * Flags to conrol replication, e.g. transfer strategy.
+     * Flags to control replication, e.g. transfer strategy.
      * </pre>
      */
     public boolean hasReplicationFlags() {
@@ -2959,7 +3095,7 @@ public final class GlobalTypes {
      * <code>required fixed32 replication_flags = 2;</code>
      *
      * <pre>
-     * Flags to conrol replication, e.g. transfer strategy.
+     * Flags to control replication, e.g. transfer strategy.
      * </pre>
      */
     public int getReplicationFlags() {
@@ -3465,7 +3601,7 @@ public final class GlobalTypes {
        * <code>required fixed32 replication_flags = 2;</code>
        *
        * <pre>
-       * Flags to conrol replication, e.g. transfer strategy.
+       * Flags to control replication, e.g. transfer strategy.
        * </pre>
        */
       public boolean hasReplicationFlags() {
@@ -3475,7 +3611,7 @@ public final class GlobalTypes {
        * <code>required fixed32 replication_flags = 2;</code>
        *
        * <pre>
-       * Flags to conrol replication, e.g. transfer strategy.
+       * Flags to control replication, e.g. transfer strategy.
        * </pre>
        */
       public int getReplicationFlags() {
@@ -3485,7 +3621,7 @@ public final class GlobalTypes {
        * <code>required fixed32 replication_flags = 2;</code>
        *
        * <pre>
-       * Flags to conrol replication, e.g. transfer strategy.
+       * Flags to control replication, e.g. transfer strategy.
        * </pre>
        */
       public Builder setReplicationFlags(int value) {
@@ -3498,7 +3634,7 @@ public final class GlobalTypes {
        * <code>required fixed32 replication_flags = 2;</code>
        *
        * <pre>
-       * Flags to conrol replication, e.g. transfer strategy.
+       * Flags to control replication, e.g. transfer strategy.
        * </pre>
        */
       public Builder clearReplicationFlags() {
@@ -10694,30 +10830,32 @@ public final class GlobalTypes {
       "LED\020\000\022\036\n\032SNAP_CONFIG_ACCESS_CURRENT\020\001\022\033\n",
       "\027SNAP_CONFIG_ACCESS_SNAP\020\002*P\n\022StripingPo" +
       "licyType\022\031\n\025STRIPING_POLICY_RAID0\020\000\022\037\n\033S" +
-      "TRIPING_POLICY_ERASURECODE\020\001*\270\001\n\005PORTS\022\033" +
-      "\n\025DIR_HTTP_PORT_DEFAULT\020\256\357\001\022\034\n\026DIR_PBRPC" +
-      "_PORT_DEFAULT\020\376\376\001\022\033\n\025MRC_HTTP_PORT_DEFAU" +
-      "LT\020\254\357\001\022\034\n\026MRC_PBRPC_PORT_DEFAULT\020\374\376\001\022\033\n\025" +
-      "OSD_HTTP_PORT_DEFAULT\020\260\357\001\022\034\n\026OSD_PBRPC_P" +
-      "ORT_DEFAULT\020\200\377\001*+\n\tCONSTANTS\022\036\n\032XCAP_REN" +
-      "EW_INTERVAL_IN_MIN\020\001*\202\003\n\016SYSTEM_V_FCNTL\022" +
-      "\035\n\031SYSTEM_V_FCNTL_H_O_RDONLY\020\000\022\035\n\031SYSTEM",
-      "_V_FCNTL_H_O_WRONLY\020\001\022\033\n\027SYSTEM_V_FCNTL_" +
-      "H_O_RDWR\020\002\022\035\n\031SYSTEM_V_FCNTL_H_O_APPEND\020" +
-      "\010\022\035\n\030SYSTEM_V_FCNTL_H_O_CREAT\020\200\002\022\035\n\030SYST" +
-      "EM_V_FCNTL_H_O_TRUNC\020\200\004\022\034\n\027SYSTEM_V_FCNT" +
-      "L_H_O_EXCL\020\200\010\022\033\n\027SYSTEM_V_FCNTL_H_O_SYNC" +
-      "\020\020\022\036\n\030SYSTEM_V_FCNTL_H_S_IFREG\020\200\200\002\022\036\n\030SY" +
-      "STEM_V_FCNTL_H_S_IFDIR\020\200\200\001\022\036\n\030SYSTEM_V_F" +
-      "CNTL_H_S_IFLNK\020\200\300\002\022\035\n\030SYSTEM_V_FCNTL_H_S" +
-      "_IFIFO\020\200 *\330\001\n\tREPL_FLAG\022\032\n\026REPL_FLAG_FUL" +
-      "L_REPLICA\020\001\022\031\n\025REPL_FLAG_IS_COMPLETE\020\002\022\035",
-      "\n\031REPL_FLAG_STRATEGY_RANDOM\020\004\022#\n\037REPL_FL" +
-      "AG_STRATEGY_RAREST_FIRST\020\010\022!\n\035REPL_FLAG_" +
-      "STRATEGY_SEQUENTIAL\020\020\022-\n)REPL_FLAG_STRAT" +
-      "EGY_SEQUENTIAL_PREFETCHING\020 *%\n\010SERVICES" +
-      "\022\007\n\003DIR\020\001\022\007\n\003MRC\020\002\022\007\n\003OSD\020\003B(\n&org.xtree" +
-      "mfs.pbrpc.generatedinterfaces"
+      "TRIPING_POLICY_ERASURECODE\020\001*9\n\nLeaseSta" +
+      "te\022\010\n\004NONE\020\000\022\013\n\007PRIMARY\020\001\022\n\n\006BACKUP\020\002\022\010\n" +
+      "\004IDLE\020\003*\270\001\n\005PORTS\022\033\n\025DIR_HTTP_PORT_DEFAU" +
+      "LT\020\256\357\001\022\034\n\026DIR_PBRPC_PORT_DEFAULT\020\376\376\001\022\033\n\025" +
+      "MRC_HTTP_PORT_DEFAULT\020\254\357\001\022\034\n\026MRC_PBRPC_P" +
+      "ORT_DEFAULT\020\374\376\001\022\033\n\025OSD_HTTP_PORT_DEFAULT" +
+      "\020\260\357\001\022\034\n\026OSD_PBRPC_PORT_DEFAULT\020\200\377\001*+\n\tCO" +
+      "NSTANTS\022\036\n\032XCAP_RENEW_INTERVAL_IN_MIN\020\001*",
+      "\202\003\n\016SYSTEM_V_FCNTL\022\035\n\031SYSTEM_V_FCNTL_H_O" +
+      "_RDONLY\020\000\022\035\n\031SYSTEM_V_FCNTL_H_O_WRONLY\020\001" +
+      "\022\033\n\027SYSTEM_V_FCNTL_H_O_RDWR\020\002\022\035\n\031SYSTEM_" +
+      "V_FCNTL_H_O_APPEND\020\010\022\035\n\030SYSTEM_V_FCNTL_H" +
+      "_O_CREAT\020\200\002\022\035\n\030SYSTEM_V_FCNTL_H_O_TRUNC\020" +
+      "\200\004\022\034\n\027SYSTEM_V_FCNTL_H_O_EXCL\020\200\010\022\033\n\027SYST" +
+      "EM_V_FCNTL_H_O_SYNC\020\020\022\036\n\030SYSTEM_V_FCNTL_" +
+      "H_S_IFREG\020\200\200\002\022\036\n\030SYSTEM_V_FCNTL_H_S_IFDI" +
+      "R\020\200\200\001\022\036\n\030SYSTEM_V_FCNTL_H_S_IFLNK\020\200\300\002\022\035\n" +
+      "\030SYSTEM_V_FCNTL_H_S_IFIFO\020\200 *\330\001\n\tREPL_FL",
+      "AG\022\032\n\026REPL_FLAG_FULL_REPLICA\020\001\022\031\n\025REPL_F" +
+      "LAG_IS_COMPLETE\020\002\022\035\n\031REPL_FLAG_STRATEGY_" +
+      "RANDOM\020\004\022#\n\037REPL_FLAG_STRATEGY_RAREST_FI" +
+      "RST\020\010\022!\n\035REPL_FLAG_STRATEGY_SEQUENTIAL\020\020" +
+      "\022-\n)REPL_FLAG_STRATEGY_SEQUENTIAL_PREFET" +
+      "CHING\020 *%\n\010SERVICES\022\007\n\003DIR\020\001\022\007\n\003MRC\020\002\022\007\n" +
+      "\003OSD\020\003B(\n&org.xtreemfs.pbrpc.generatedin" +
+      "terfaces"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {

--- a/java/servers/src/org/xtreemfs/pbrpc/generatedinterfaces/MRC.java
+++ b/java/servers/src/org/xtreemfs/pbrpc/generatedinterfaces/MRC.java
@@ -34363,7 +34363,8 @@ public final class MRC {
      * <code>required fixed32 num_osds = 2;</code>
      *
      * <pre>
-     * the number of OSDs for the new replicas
+     * the number of OSDs required in a valid group
+     * ignored by filtering and sorting policies
      * </pre>
      */
     boolean hasNumOsds();
@@ -34371,7 +34372,8 @@ public final class MRC {
      * <code>required fixed32 num_osds = 2;</code>
      *
      * <pre>
-     * the number of OSDs for the new replicas
+     * the number of OSDs required in a valid group
+     * ignored by filtering and sorting policies
      * </pre>
      */
     int getNumOsds();
@@ -34651,7 +34653,8 @@ public final class MRC {
      * <code>required fixed32 num_osds = 2;</code>
      *
      * <pre>
-     * the number of OSDs for the new replicas
+     * the number of OSDs required in a valid group
+     * ignored by filtering and sorting policies
      * </pre>
      */
     public boolean hasNumOsds() {
@@ -34661,7 +34664,8 @@ public final class MRC {
      * <code>required fixed32 num_osds = 2;</code>
      *
      * <pre>
-     * the number of OSDs for the new replicas
+     * the number of OSDs required in a valid group
+     * ignored by filtering and sorting policies
      * </pre>
      */
     public int getNumOsds() {
@@ -35240,7 +35244,8 @@ public final class MRC {
        * <code>required fixed32 num_osds = 2;</code>
        *
        * <pre>
-       * the number of OSDs for the new replicas
+       * the number of OSDs required in a valid group
+       * ignored by filtering and sorting policies
        * </pre>
        */
       public boolean hasNumOsds() {
@@ -35250,7 +35255,8 @@ public final class MRC {
        * <code>required fixed32 num_osds = 2;</code>
        *
        * <pre>
-       * the number of OSDs for the new replicas
+       * the number of OSDs required in a valid group
+       * ignored by filtering and sorting policies
        * </pre>
        */
       public int getNumOsds() {
@@ -35260,7 +35266,8 @@ public final class MRC {
        * <code>required fixed32 num_osds = 2;</code>
        *
        * <pre>
-       * the number of OSDs for the new replicas
+       * the number of OSDs required in a valid group
+       * ignored by filtering and sorting policies
        * </pre>
        */
       public Builder setNumOsds(int value) {
@@ -35273,7 +35280,8 @@ public final class MRC {
        * <code>required fixed32 num_osds = 2;</code>
        *
        * <pre>
-       * the number of OSDs for the new replicas
+       * the number of OSDs required in a valid group
+       * ignored by filtering and sorting policies
        * </pre>
        */
       public Builder clearNumOsds() {

--- a/java/servers/src/org/xtreemfs/pbrpc/generatedinterfaces/OSD.java
+++ b/java/servers/src/org/xtreemfs/pbrpc/generatedinterfaces/OSD.java
@@ -32093,15 +32093,15 @@ public final class OSD {
   public interface xtreemfs_xloc_set_invalidateResponseOrBuilder
       extends com.google.protobuf.MessageOrBuilder {
 
-    // required .xtreemfs.pbrpc.xtreemfs_xloc_set_invalidateResponse.LeaseState lease_state = 1;
+    // required .xtreemfs.pbrpc.LeaseState lease_state = 1;
     /**
-     * <code>required .xtreemfs.pbrpc.xtreemfs_xloc_set_invalidateResponse.LeaseState lease_state = 1;</code>
+     * <code>required .xtreemfs.pbrpc.LeaseState lease_state = 1;</code>
      */
     boolean hasLeaseState();
     /**
-     * <code>required .xtreemfs.pbrpc.xtreemfs_xloc_set_invalidateResponse.LeaseState lease_state = 1;</code>
+     * <code>required .xtreemfs.pbrpc.LeaseState lease_state = 1;</code>
      */
-    org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_xloc_set_invalidateResponse.LeaseState getLeaseState();
+    org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.LeaseState getLeaseState();
 
     // optional .xtreemfs.pbrpc.ReplicaStatus replica_status = 2;
     /**
@@ -32170,7 +32170,7 @@ public final class OSD {
             }
             case 8: {
               int rawValue = input.readEnum();
-              org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_xloc_set_invalidateResponse.LeaseState value = org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_xloc_set_invalidateResponse.LeaseState.valueOf(rawValue);
+              org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.LeaseState value = org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.LeaseState.valueOf(rawValue);
               if (value == null) {
                 unknownFields.mergeVarintField(1, rawValue);
               } else {
@@ -32231,152 +32231,20 @@ public final class OSD {
       return PARSER;
     }
 
-    /**
-     * Protobuf enum {@code xtreemfs.pbrpc.xtreemfs_xloc_set_invalidateResponse.LeaseState}
-     */
-    public enum LeaseState
-        implements com.google.protobuf.ProtocolMessageEnum {
-      /**
-       * <code>NONE = 0;</code>
-       *
-       * <pre>
-       * The replica doesn't use lease, or an error occured.
-       * </pre>
-       */
-      NONE(0, 0),
-      /**
-       * <code>PRIMARY = 1;</code>
-       *
-       * <pre>
-       * The replica has been the primary.
-       * </pre>
-       */
-      PRIMARY(1, 1),
-      /**
-       * <code>BACKUP = 2;</code>
-       *
-       * <pre>
-       * The replica has been a backup with an active primary.
-       * </pre>
-       */
-      BACKUP(2, 2),
-      /**
-       * <code>IDLE = 3;</code>
-       *
-       * <pre>
-       * The replica is not active/opened.
-       * </pre>
-       */
-      IDLE(3, 3),
-      ;
-
-      /**
-       * <code>NONE = 0;</code>
-       *
-       * <pre>
-       * The replica doesn't use lease, or an error occured.
-       * </pre>
-       */
-      public static final int NONE_VALUE = 0;
-      /**
-       * <code>PRIMARY = 1;</code>
-       *
-       * <pre>
-       * The replica has been the primary.
-       * </pre>
-       */
-      public static final int PRIMARY_VALUE = 1;
-      /**
-       * <code>BACKUP = 2;</code>
-       *
-       * <pre>
-       * The replica has been a backup with an active primary.
-       * </pre>
-       */
-      public static final int BACKUP_VALUE = 2;
-      /**
-       * <code>IDLE = 3;</code>
-       *
-       * <pre>
-       * The replica is not active/opened.
-       * </pre>
-       */
-      public static final int IDLE_VALUE = 3;
-
-
-      public final int getNumber() { return value; }
-
-      public static LeaseState valueOf(int value) {
-        switch (value) {
-          case 0: return NONE;
-          case 1: return PRIMARY;
-          case 2: return BACKUP;
-          case 3: return IDLE;
-          default: return null;
-        }
-      }
-
-      public static com.google.protobuf.Internal.EnumLiteMap<LeaseState>
-          internalGetValueMap() {
-        return internalValueMap;
-      }
-      private static com.google.protobuf.Internal.EnumLiteMap<LeaseState>
-          internalValueMap =
-            new com.google.protobuf.Internal.EnumLiteMap<LeaseState>() {
-              public LeaseState findValueByNumber(int number) {
-                return LeaseState.valueOf(number);
-              }
-            };
-
-      public final com.google.protobuf.Descriptors.EnumValueDescriptor
-          getValueDescriptor() {
-        return getDescriptor().getValues().get(index);
-      }
-      public final com.google.protobuf.Descriptors.EnumDescriptor
-          getDescriptorForType() {
-        return getDescriptor();
-      }
-      public static final com.google.protobuf.Descriptors.EnumDescriptor
-          getDescriptor() {
-        return org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_xloc_set_invalidateResponse.getDescriptor().getEnumTypes().get(0);
-      }
-
-      private static final LeaseState[] VALUES = values();
-
-      public static LeaseState valueOf(
-          com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
-        if (desc.getType() != getDescriptor()) {
-          throw new java.lang.IllegalArgumentException(
-            "EnumValueDescriptor is not for this type.");
-        }
-        return VALUES[desc.getIndex()];
-      }
-
-      private final int index;
-      private final int value;
-
-      private LeaseState(int index, int value) {
-        this.index = index;
-        this.value = value;
-      }
-
-      // @@protoc_insertion_point(enum_scope:xtreemfs.pbrpc.xtreemfs_xloc_set_invalidateResponse.LeaseState)
-    }
-
     private int bitField0_;
-    // required .xtreemfs.pbrpc.xtreemfs_xloc_set_invalidateResponse.LeaseState lease_state = 1;
+    // required .xtreemfs.pbrpc.LeaseState lease_state = 1;
     public static final int LEASE_STATE_FIELD_NUMBER = 1;
-    private org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_xloc_set_invalidateResponse.LeaseState leaseState_;
+    private org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.LeaseState leaseState_;
     /**
-     * <code>required .xtreemfs.pbrpc.xtreemfs_xloc_set_invalidateResponse.LeaseState lease_state = 1;</code>
+     * <code>required .xtreemfs.pbrpc.LeaseState lease_state = 1;</code>
      */
     public boolean hasLeaseState() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
-     * <code>required .xtreemfs.pbrpc.xtreemfs_xloc_set_invalidateResponse.LeaseState lease_state = 1;</code>
+     * <code>required .xtreemfs.pbrpc.LeaseState lease_state = 1;</code>
      */
-    public org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_xloc_set_invalidateResponse.LeaseState getLeaseState() {
+    public org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.LeaseState getLeaseState() {
       return leaseState_;
     }
 
@@ -32403,7 +32271,7 @@ public final class OSD {
     }
 
     private void initFields() {
-      leaseState_ = org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_xloc_set_invalidateResponse.LeaseState.NONE;
+      leaseState_ = org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.LeaseState.NONE;
       replicaStatus_ = org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus.getDefaultInstance();
     }
     private byte memoizedIsInitialized = -1;
@@ -32568,7 +32436,7 @@ public final class OSD {
 
       public Builder clear() {
         super.clear();
-        leaseState_ = org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_xloc_set_invalidateResponse.LeaseState.NONE;
+        leaseState_ = org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.LeaseState.NONE;
         bitField0_ = (bitField0_ & ~0x00000001);
         if (replicaStatusBuilder_ == null) {
           replicaStatus_ = org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus.getDefaultInstance();
@@ -32675,24 +32543,24 @@ public final class OSD {
       }
       private int bitField0_;
 
-      // required .xtreemfs.pbrpc.xtreemfs_xloc_set_invalidateResponse.LeaseState lease_state = 1;
-      private org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_xloc_set_invalidateResponse.LeaseState leaseState_ = org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_xloc_set_invalidateResponse.LeaseState.NONE;
+      // required .xtreemfs.pbrpc.LeaseState lease_state = 1;
+      private org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.LeaseState leaseState_ = org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.LeaseState.NONE;
       /**
-       * <code>required .xtreemfs.pbrpc.xtreemfs_xloc_set_invalidateResponse.LeaseState lease_state = 1;</code>
+       * <code>required .xtreemfs.pbrpc.LeaseState lease_state = 1;</code>
        */
       public boolean hasLeaseState() {
         return ((bitField0_ & 0x00000001) == 0x00000001);
       }
       /**
-       * <code>required .xtreemfs.pbrpc.xtreemfs_xloc_set_invalidateResponse.LeaseState lease_state = 1;</code>
+       * <code>required .xtreemfs.pbrpc.LeaseState lease_state = 1;</code>
        */
-      public org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_xloc_set_invalidateResponse.LeaseState getLeaseState() {
+      public org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.LeaseState getLeaseState() {
         return leaseState_;
       }
       /**
-       * <code>required .xtreemfs.pbrpc.xtreemfs_xloc_set_invalidateResponse.LeaseState lease_state = 1;</code>
+       * <code>required .xtreemfs.pbrpc.LeaseState lease_state = 1;</code>
        */
-      public Builder setLeaseState(org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_xloc_set_invalidateResponse.LeaseState value) {
+      public Builder setLeaseState(org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.LeaseState value) {
         if (value == null) {
           throw new NullPointerException();
         }
@@ -32702,11 +32570,11 @@ public final class OSD {
         return this;
       }
       /**
-       * <code>required .xtreemfs.pbrpc.xtreemfs_xloc_set_invalidateResponse.LeaseState lease_state = 1;</code>
+       * <code>required .xtreemfs.pbrpc.LeaseState lease_state = 1;</code>
        */
       public Builder clearLeaseState() {
         bitField0_ = (bitField0_ & ~0x00000001);
-        leaseState_ = org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_xloc_set_invalidateResponse.LeaseState.NONE;
+        leaseState_ = org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.LeaseState.NONE;
         onChanged();
         return this;
       }
@@ -33178,115 +33046,112 @@ public final class OSD {
       "\003 \002(\007\"q\n#xtreemfs_xloc_set_invalidateReq" +
       "uest\0229\n\020file_credentials\030\001 \002(\0132\037.xtreemf" +
       "s.pbrpc.FileCredentials\022\017\n\007file_id\030\002 \002(\t" +
-      "\"\356\001\n$xtreemfs_xloc_set_invalidateRespons" +
-      "e\022T\n\013lease_state\030\001 \002(\0162?.xtreemfs.pbrpc." +
-      "xtreemfs_xloc_set_invalidateResponse.Lea" +
-      "seState\0225\n\016replica_status\030\002 \001(\0132\035.xtreem" +
-      "fs.pbrpc.ReplicaStatus\"9\n\nLeaseState\022\010\n\004",
-      "NONE\020\000\022\013\n\007PRIMARY\020\001\022\n\n\006BACKUP\020\002\022\010\n\004IDLE\020" +
-      "\003*\215\001\n\017OSDHealthResult\022\034\n\030OSD_HEALTH_RESU" +
-      "LT_PASSED\020\000\022\035\n\031OSD_HEALTH_RESULT_WARNING" +
-      "\020\001\022\034\n\030OSD_HEALTH_RESULT_FAILED\020\002\022\037\n\033OSD_" +
-      "HEALTH_RESULT_NOT_AVAIL\020\0032\277\036\n\nOSDService" +
-      "\022L\n\004read\022\033.xtreemfs.pbrpc.readRequest\032\032." +
-      "xtreemfs.pbrpc.ObjectData\"\013\215\265\030\n\000\000\000\230\265\030\001\022V" +
-      "\n\010truncate\022\037.xtreemfs.pbrpc.truncateRequ" +
-      "est\032 .xtreemfs.pbrpc.OSDWriteResponse\"\007\215" +
-      "\265\030\013\000\000\000\022T\n\006unlink\022\".xtreemfs.pbrpc.unlink",
-      "_osd_Request\032\035.xtreemfs.pbrpc.emptyRespo" +
-      "nse\"\007\215\265\030\014\000\000\000\022T\n\005write\022\034.xtreemfs.pbrpc.w" +
-      "riteRequest\032 .xtreemfs.pbrpc.OSDWriteRes" +
-      "ponse\"\013\215\265\030\r\000\000\000\240\265\030\001\022q\n\027xtreemfs_broadcast" +
-      "_gmax\022..xtreemfs.pbrpc.xtreemfs_broadcas" +
-      "t_gmaxRequest\032\035.xtreemfs.pbrpc.emptyResp" +
-      "onse\"\007\215\265\030\024\000\000\000\022j\n\025xtreemfs_check_object\022," +
-      ".xtreemfs.pbrpc.xtreemfs_check_objectReq" +
-      "uest\032\032.xtreemfs.pbrpc.ObjectData\"\007\215\265\030\025\000\000" +
-      "\000\022{\n\034xtreemfs_cleanup_get_results\022\034.xtre",
-      "emfs.pbrpc.emptyRequest\0324.xtreemfs.pbrpc" +
-      ".xtreemfs_cleanup_get_resultsResponse\"\007\215" +
-      "\265\030\036\000\000\000\022y\n\033xtreemfs_cleanup_is_running\022\034." +
-      "xtreemfs.pbrpc.emptyRequest\0323.xtreemfs.p" +
-      "brpc.xtreemfs_cleanup_is_runningResponse" +
-      "\"\007\215\265\030\037\000\000\000\022o\n\026xtreemfs_cleanup_start\022-.xt" +
-      "reemfs.pbrpc.xtreemfs_cleanup_startReque" +
-      "st\032\035.xtreemfs.pbrpc.emptyResponse\"\007\215\265\030 \000" +
-      "\000\000\022q\n\027xtreemfs_cleanup_status\022\034.xtreemfs" +
-      ".pbrpc.emptyRequest\032/.xtreemfs.pbrpc.xtr",
-      "eemfs_cleanup_statusResponse\"\007\215\265\030!\000\000\000\022]\n" +
-      "\025xtreemfs_cleanup_stop\022\034.xtreemfs.pbrpc." +
-      "emptyRequest\032\035.xtreemfs.pbrpc.emptyRespo" +
-      "nse\"\007\215\265\030\"\000\000\000\022g\n\037xtreemfs_cleanup_version" +
-      "s_start\022\034.xtreemfs.pbrpc.emptyRequest\032\035." +
-      "xtreemfs.pbrpc.emptyResponse\"\007\215\265\030#\000\000\000\022o\n" +
-      "\026xtreemfs_repair_object\022-.xtreemfs.pbrpc" +
-      ".xtreemfs_repair_objectRequest\032\035.xtreemf" +
-      "s.pbrpc.emptyResponse\"\007\215\265\030$\000\000\000\022d\n\022xtreem" +
-      "fs_rwr_fetch\022).xtreemfs.pbrpc.xtreemfs_r",
-      "wr_fetchRequest\032\032.xtreemfs.pbrpc.ObjectD" +
-      "ata\"\007\215\265\030I\000\000\000\022u\n\027xtreemfs_rwr_flease_msg\022" +
-      "..xtreemfs.pbrpc.xtreemfs_rwr_flease_msg" +
-      "Request\032\035.xtreemfs.pbrpc.emptyResponse\"\013" +
-      "\215\265\030G\000\000\000\240\265\030\001\022^\n\023xtreemfs_rwr_notify\022\037.xtr" +
-      "eemfs.pbrpc.FileCredentials\032\035.xtreemfs.p" +
-      "brpc.emptyResponse\"\007\215\265\030K\000\000\000\022|\n\036xtreemfs_" +
-      "rwr_set_primary_epoch\0225.xtreemfs.pbrpc.x" +
-      "treemfs_rwr_set_primary_epochRequest\032\032.x" +
-      "treemfs.pbrpc.ObjectData\"\007\215\265\030N\000\000\000\022i\n\023xtr",
-      "eemfs_rwr_status\022*.xtreemfs.pbrpc.xtreem" +
-      "fs_rwr_statusRequest\032\035.xtreemfs.pbrpc.Re" +
-      "plicaStatus\"\007\215\265\030L\000\000\000\022m\n\025xtreemfs_rwr_tru" +
-      "ncate\022,.xtreemfs.pbrpc.xtreemfs_rwr_trun" +
-      "cateRequest\032\035.xtreemfs.pbrpc.emptyRespon" +
-      "se\"\007\215\265\030J\000\000\000\022m\n\023xtreemfs_rwr_update\022*.xtr" +
-      "eemfs.pbrpc.xtreemfs_rwr_updateRequest\032\035" +
-      ".xtreemfs.pbrpc.emptyResponse\"\013\215\265\030H\000\000\000\240\265" +
-      "\030\001\022q\n\027xtreemfs_rwr_auth_state\022..xtreemfs" +
-      ".pbrpc.xtreemfs_rwr_auth_stateRequest\032\035.",
-      "xtreemfs.pbrpc.emptyResponse\"\007\215\265\030O\000\000\000\022y\n" +
-      "\033xtreemfs_rwr_reset_complete\0222.xtreemfs." +
-      "pbrpc.xtreemfs_rwr_reset_completeRequest" +
-      "\032\035.xtreemfs.pbrpc.emptyResponse\"\007\215\265\030P\000\000\000" +
-      "\022v\n\032xtreemfs_internal_get_gmax\0221.xtreemf" +
-      "s.pbrpc.xtreemfs_internal_get_gmaxReques" +
-      "t\032\034.xtreemfs.pbrpc.InternalGmax\"\007\215\265\030(\000\000\000" +
-      "\022h\n\032xtreemfs_internal_truncate\022\037.xtreemf" +
-      "s.pbrpc.truncateRequest\032 .xtreemfs.pbrpc" +
-      ".OSDWriteResponse\"\007\215\265\030)\000\000\000\022\233\001\n\037xtreemfs_",
-      "internal_get_file_size\0226.xtreemfs.pbrpc." +
-      "xtreemfs_internal_get_file_sizeRequest\0327" +
-      ".xtreemfs.pbrpc.xtreemfs_internal_get_fi" +
-      "le_sizeResponse\"\007\215\265\030*\000\000\000\022\207\001\n\034xtreemfs_in" +
-      "ternal_read_local\0223.xtreemfs.pbrpc.xtree" +
-      "mfs_internal_read_localRequest\032).xtreemf" +
-      "s.pbrpc.InternalReadLocalResponse\"\007\215\265\030+\000" +
-      "\000\000\022\200\001\n xtreemfs_internal_get_object_set\022" +
-      "7.xtreemfs.pbrpc.xtreemfs_internal_get_o" +
-      "bject_setRequest\032\032.xtreemfs.pbrpc.Object",
-      "List\"\007\215\265\030,\000\000\000\022\205\001\n!xtreemfs_internal_get_" +
-      "fileid_list\022\034.xtreemfs.pbrpc.emptyReques" +
-      "t\0329.xtreemfs.pbrpc.xtreemfs_internal_get" +
-      "_fileid_listResponse\"\007\215\265\030-\000\000\000\022S\n\025xtreemf" +
-      "s_lock_acquire\022\033.xtreemfs.pbrpc.lockRequ" +
-      "est\032\024.xtreemfs.pbrpc.Lock\"\007\215\265\0302\000\000\000\022Q\n\023xt" +
-      "reemfs_lock_check\022\033.xtreemfs.pbrpc.lockR" +
-      "equest\032\024.xtreemfs.pbrpc.Lock\"\007\215\265\0303\000\000\000\022\\\n" +
-      "\025xtreemfs_lock_release\022\033.xtreemfs.pbrpc." +
-      "lockRequest\032\035.xtreemfs.pbrpc.emptyRespon",
-      "se\"\007\215\265\0304\000\000\000\022f\n\rxtreemfs_ping\022%.xtreemfs." +
-      "pbrpc.xtreemfs_pingMesssage\032%.xtreemfs.p" +
-      "brpc.xtreemfs_pingMesssage\"\007\215\265\030<\000\000\000\022Y\n\021x" +
-      "treemfs_shutdown\022\034.xtreemfs.pbrpc.emptyR" +
-      "equest\032\035.xtreemfs.pbrpc.emptyResponse\"\007\215" +
-      "\265\030F\000\000\000\022\222\001\n\034xtreemfs_xloc_set_invalidate\022" +
-      "3.xtreemfs.pbrpc.xtreemfs_xloc_set_inval" +
-      "idateRequest\0324.xtreemfs.pbrpc.xtreemfs_x" +
-      "loc_set_invalidateResponse\"\007\215\265\030Q\000\000\000\022}\n#x" +
-      "treemfs_rwr_auth_state_invalidated\022..xtr",
-      "eemfs.pbrpc.xtreemfs_rwr_auth_stateReque" +
-      "st\032\035.xtreemfs.pbrpc.emptyResponse\"\007\215\265\030R\000" +
-      "\000\000\032\007\225\265\0301u\000\000B(\n&org.xtreemfs.pbrpc.genera" +
-      "tedinterfaces"
+      "\"\216\001\n$xtreemfs_xloc_set_invalidateRespons" +
+      "e\022/\n\013lease_state\030\001 \002(\0162\032.xtreemfs.pbrpc." +
+      "LeaseState\0225\n\016replica_status\030\002 \001(\0132\035.xtr" +
+      "eemfs.pbrpc.ReplicaStatus*\215\001\n\017OSDHealthR" +
+      "esult\022\034\n\030OSD_HEALTH_RESULT_PASSED\020\000\022\035\n\031O",
+      "SD_HEALTH_RESULT_WARNING\020\001\022\034\n\030OSD_HEALTH" +
+      "_RESULT_FAILED\020\002\022\037\n\033OSD_HEALTH_RESULT_NO" +
+      "T_AVAIL\020\0032\277\036\n\nOSDService\022L\n\004read\022\033.xtree" +
+      "mfs.pbrpc.readRequest\032\032.xtreemfs.pbrpc.O" +
+      "bjectData\"\013\215\265\030\n\000\000\000\230\265\030\001\022V\n\010truncate\022\037.xtr" +
+      "eemfs.pbrpc.truncateRequest\032 .xtreemfs.p" +
+      "brpc.OSDWriteResponse\"\007\215\265\030\013\000\000\000\022T\n\006unlink" +
+      "\022\".xtreemfs.pbrpc.unlink_osd_Request\032\035.x" +
+      "treemfs.pbrpc.emptyResponse\"\007\215\265\030\014\000\000\000\022T\n\005" +
+      "write\022\034.xtreemfs.pbrpc.writeRequest\032 .xt",
+      "reemfs.pbrpc.OSDWriteResponse\"\013\215\265\030\r\000\000\000\240\265" +
+      "\030\001\022q\n\027xtreemfs_broadcast_gmax\022..xtreemfs" +
+      ".pbrpc.xtreemfs_broadcast_gmaxRequest\032\035." +
+      "xtreemfs.pbrpc.emptyResponse\"\007\215\265\030\024\000\000\000\022j\n" +
+      "\025xtreemfs_check_object\022,.xtreemfs.pbrpc." +
+      "xtreemfs_check_objectRequest\032\032.xtreemfs." +
+      "pbrpc.ObjectData\"\007\215\265\030\025\000\000\000\022{\n\034xtreemfs_cl" +
+      "eanup_get_results\022\034.xtreemfs.pbrpc.empty" +
+      "Request\0324.xtreemfs.pbrpc.xtreemfs_cleanu" +
+      "p_get_resultsResponse\"\007\215\265\030\036\000\000\000\022y\n\033xtreem",
+      "fs_cleanup_is_running\022\034.xtreemfs.pbrpc.e" +
+      "mptyRequest\0323.xtreemfs.pbrpc.xtreemfs_cl" +
+      "eanup_is_runningResponse\"\007\215\265\030\037\000\000\000\022o\n\026xtr" +
+      "eemfs_cleanup_start\022-.xtreemfs.pbrpc.xtr" +
+      "eemfs_cleanup_startRequest\032\035.xtreemfs.pb" +
+      "rpc.emptyResponse\"\007\215\265\030 \000\000\000\022q\n\027xtreemfs_c" +
+      "leanup_status\022\034.xtreemfs.pbrpc.emptyRequ" +
+      "est\032/.xtreemfs.pbrpc.xtreemfs_cleanup_st" +
+      "atusResponse\"\007\215\265\030!\000\000\000\022]\n\025xtreemfs_cleanu" +
+      "p_stop\022\034.xtreemfs.pbrpc.emptyRequest\032\035.x",
+      "treemfs.pbrpc.emptyResponse\"\007\215\265\030\"\000\000\000\022g\n\037" +
+      "xtreemfs_cleanup_versions_start\022\034.xtreem" +
+      "fs.pbrpc.emptyRequest\032\035.xtreemfs.pbrpc.e" +
+      "mptyResponse\"\007\215\265\030#\000\000\000\022o\n\026xtreemfs_repair" +
+      "_object\022-.xtreemfs.pbrpc.xtreemfs_repair" +
+      "_objectRequest\032\035.xtreemfs.pbrpc.emptyRes" +
+      "ponse\"\007\215\265\030$\000\000\000\022d\n\022xtreemfs_rwr_fetch\022).x" +
+      "treemfs.pbrpc.xtreemfs_rwr_fetchRequest\032" +
+      "\032.xtreemfs.pbrpc.ObjectData\"\007\215\265\030I\000\000\000\022u\n\027" +
+      "xtreemfs_rwr_flease_msg\022..xtreemfs.pbrpc",
+      ".xtreemfs_rwr_flease_msgRequest\032\035.xtreem" +
+      "fs.pbrpc.emptyResponse\"\013\215\265\030G\000\000\000\240\265\030\001\022^\n\023x" +
+      "treemfs_rwr_notify\022\037.xtreemfs.pbrpc.File" +
+      "Credentials\032\035.xtreemfs.pbrpc.emptyRespon" +
+      "se\"\007\215\265\030K\000\000\000\022|\n\036xtreemfs_rwr_set_primary_" +
+      "epoch\0225.xtreemfs.pbrpc.xtreemfs_rwr_set_" +
+      "primary_epochRequest\032\032.xtreemfs.pbrpc.Ob" +
+      "jectData\"\007\215\265\030N\000\000\000\022i\n\023xtreemfs_rwr_status" +
+      "\022*.xtreemfs.pbrpc.xtreemfs_rwr_statusReq" +
+      "uest\032\035.xtreemfs.pbrpc.ReplicaStatus\"\007\215\265\030",
+      "L\000\000\000\022m\n\025xtreemfs_rwr_truncate\022,.xtreemfs" +
+      ".pbrpc.xtreemfs_rwr_truncateRequest\032\035.xt" +
+      "reemfs.pbrpc.emptyResponse\"\007\215\265\030J\000\000\000\022m\n\023x" +
+      "treemfs_rwr_update\022*.xtreemfs.pbrpc.xtre" +
+      "emfs_rwr_updateRequest\032\035.xtreemfs.pbrpc." +
+      "emptyResponse\"\013\215\265\030H\000\000\000\240\265\030\001\022q\n\027xtreemfs_r" +
+      "wr_auth_state\022..xtreemfs.pbrpc.xtreemfs_" +
+      "rwr_auth_stateRequest\032\035.xtreemfs.pbrpc.e" +
+      "mptyResponse\"\007\215\265\030O\000\000\000\022y\n\033xtreemfs_rwr_re" +
+      "set_complete\0222.xtreemfs.pbrpc.xtreemfs_r",
+      "wr_reset_completeRequest\032\035.xtreemfs.pbrp" +
+      "c.emptyResponse\"\007\215\265\030P\000\000\000\022v\n\032xtreemfs_int" +
+      "ernal_get_gmax\0221.xtreemfs.pbrpc.xtreemfs" +
+      "_internal_get_gmaxRequest\032\034.xtreemfs.pbr" +
+      "pc.InternalGmax\"\007\215\265\030(\000\000\000\022h\n\032xtreemfs_int" +
+      "ernal_truncate\022\037.xtreemfs.pbrpc.truncate" +
+      "Request\032 .xtreemfs.pbrpc.OSDWriteRespons" +
+      "e\"\007\215\265\030)\000\000\000\022\233\001\n\037xtreemfs_internal_get_fil" +
+      "e_size\0226.xtreemfs.pbrpc.xtreemfs_interna" +
+      "l_get_file_sizeRequest\0327.xtreemfs.pbrpc.",
+      "xtreemfs_internal_get_file_sizeResponse\"" +
+      "\007\215\265\030*\000\000\000\022\207\001\n\034xtreemfs_internal_read_loca" +
+      "l\0223.xtreemfs.pbrpc.xtreemfs_internal_rea" +
+      "d_localRequest\032).xtreemfs.pbrpc.Internal" +
+      "ReadLocalResponse\"\007\215\265\030+\000\000\000\022\200\001\n xtreemfs_" +
+      "internal_get_object_set\0227.xtreemfs.pbrpc" +
+      ".xtreemfs_internal_get_object_setRequest" +
+      "\032\032.xtreemfs.pbrpc.ObjectList\"\007\215\265\030,\000\000\000\022\205\001" +
+      "\n!xtreemfs_internal_get_fileid_list\022\034.xt" +
+      "reemfs.pbrpc.emptyRequest\0329.xtreemfs.pbr",
+      "pc.xtreemfs_internal_get_fileid_listResp" +
+      "onse\"\007\215\265\030-\000\000\000\022S\n\025xtreemfs_lock_acquire\022\033" +
+      ".xtreemfs.pbrpc.lockRequest\032\024.xtreemfs.p" +
+      "brpc.Lock\"\007\215\265\0302\000\000\000\022Q\n\023xtreemfs_lock_chec" +
+      "k\022\033.xtreemfs.pbrpc.lockRequest\032\024.xtreemf" +
+      "s.pbrpc.Lock\"\007\215\265\0303\000\000\000\022\\\n\025xtreemfs_lock_r" +
+      "elease\022\033.xtreemfs.pbrpc.lockRequest\032\035.xt" +
+      "reemfs.pbrpc.emptyResponse\"\007\215\265\0304\000\000\000\022f\n\rx" +
+      "treemfs_ping\022%.xtreemfs.pbrpc.xtreemfs_p" +
+      "ingMesssage\032%.xtreemfs.pbrpc.xtreemfs_pi",
+      "ngMesssage\"\007\215\265\030<\000\000\000\022Y\n\021xtreemfs_shutdown" +
+      "\022\034.xtreemfs.pbrpc.emptyRequest\032\035.xtreemf" +
+      "s.pbrpc.emptyResponse\"\007\215\265\030F\000\000\000\022\222\001\n\034xtree" +
+      "mfs_xloc_set_invalidate\0223.xtreemfs.pbrpc" +
+      ".xtreemfs_xloc_set_invalidateRequest\0324.x" +
+      "treemfs.pbrpc.xtreemfs_xloc_set_invalida" +
+      "teResponse\"\007\215\265\030Q\000\000\000\022}\n#xtreemfs_rwr_auth" +
+      "_state_invalidated\022..xtreemfs.pbrpc.xtre" +
+      "emfs_rwr_auth_stateRequest\032\035.xtreemfs.pb" +
+      "rpc.emptyResponse\"\007\215\265\030R\000\000\000\032\007\225\265\0301u\000\000B(\n&o",
+      "rg.xtreemfs.pbrpc.generatedinterfaces"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {

--- a/java/servers/src/org/xtreemfs/pbrpc/generatedinterfaces/OSD.java
+++ b/java/servers/src/org/xtreemfs/pbrpc/generatedinterfaces/OSD.java
@@ -32093,29 +32093,29 @@ public final class OSD {
   public interface xtreemfs_xloc_set_invalidateResponseOrBuilder
       extends com.google.protobuf.MessageOrBuilder {
 
-    // required bool is_primary = 1;
+    // required .xtreemfs.pbrpc.xtreemfs_xloc_set_invalidateResponse.LeaseState lease_state = 1;
     /**
-     * <code>required bool is_primary = 1;</code>
+     * <code>required .xtreemfs.pbrpc.xtreemfs_xloc_set_invalidateResponse.LeaseState lease_state = 1;</code>
      */
-    boolean hasIsPrimary();
+    boolean hasLeaseState();
     /**
-     * <code>required bool is_primary = 1;</code>
+     * <code>required .xtreemfs.pbrpc.xtreemfs_xloc_set_invalidateResponse.LeaseState lease_state = 1;</code>
      */
-    boolean getIsPrimary();
+    org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_xloc_set_invalidateResponse.LeaseState getLeaseState();
 
-    // optional .xtreemfs.pbrpc.ReplicaStatus status = 2;
+    // optional .xtreemfs.pbrpc.ReplicaStatus replica_status = 2;
     /**
-     * <code>optional .xtreemfs.pbrpc.ReplicaStatus status = 2;</code>
+     * <code>optional .xtreemfs.pbrpc.ReplicaStatus replica_status = 2;</code>
      */
-    boolean hasStatus();
+    boolean hasReplicaStatus();
     /**
-     * <code>optional .xtreemfs.pbrpc.ReplicaStatus status = 2;</code>
+     * <code>optional .xtreemfs.pbrpc.ReplicaStatus replica_status = 2;</code>
      */
-    org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus getStatus();
+    org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus getReplicaStatus();
     /**
-     * <code>optional .xtreemfs.pbrpc.ReplicaStatus status = 2;</code>
+     * <code>optional .xtreemfs.pbrpc.ReplicaStatus replica_status = 2;</code>
      */
-    org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatusOrBuilder getStatusOrBuilder();
+    org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatusOrBuilder getReplicaStatusOrBuilder();
   }
   /**
    * Protobuf type {@code xtreemfs.pbrpc.xtreemfs_xloc_set_invalidateResponse}
@@ -32169,19 +32169,25 @@ public final class OSD {
               break;
             }
             case 8: {
-              bitField0_ |= 0x00000001;
-              isPrimary_ = input.readBool();
+              int rawValue = input.readEnum();
+              org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_xloc_set_invalidateResponse.LeaseState value = org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_xloc_set_invalidateResponse.LeaseState.valueOf(rawValue);
+              if (value == null) {
+                unknownFields.mergeVarintField(1, rawValue);
+              } else {
+                bitField0_ |= 0x00000001;
+                leaseState_ = value;
+              }
               break;
             }
             case 18: {
               org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus.Builder subBuilder = null;
               if (((bitField0_ & 0x00000002) == 0x00000002)) {
-                subBuilder = status_.toBuilder();
+                subBuilder = replicaStatus_.toBuilder();
               }
-              status_ = input.readMessage(org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus.PARSER, extensionRegistry);
+              replicaStatus_ = input.readMessage(org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus.PARSER, extensionRegistry);
               if (subBuilder != null) {
-                subBuilder.mergeFrom(status_);
-                status_ = subBuilder.buildPartial();
+                subBuilder.mergeFrom(replicaStatus_);
+                replicaStatus_ = subBuilder.buildPartial();
               }
               bitField0_ |= 0x00000002;
               break;
@@ -32225,60 +32231,192 @@ public final class OSD {
       return PARSER;
     }
 
-    private int bitField0_;
-    // required bool is_primary = 1;
-    public static final int IS_PRIMARY_FIELD_NUMBER = 1;
-    private boolean isPrimary_;
     /**
-     * <code>required bool is_primary = 1;</code>
+     * Protobuf enum {@code xtreemfs.pbrpc.xtreemfs_xloc_set_invalidateResponse.LeaseState}
      */
-    public boolean hasIsPrimary() {
+    public enum LeaseState
+        implements com.google.protobuf.ProtocolMessageEnum {
+      /**
+       * <code>NONE = 0;</code>
+       *
+       * <pre>
+       * The replica doesn't use lease, or an error occured.
+       * </pre>
+       */
+      NONE(0, 0),
+      /**
+       * <code>PRIMARY = 1;</code>
+       *
+       * <pre>
+       * The replica has been the primary.
+       * </pre>
+       */
+      PRIMARY(1, 1),
+      /**
+       * <code>BACKUP = 2;</code>
+       *
+       * <pre>
+       * The replica has been a backup with an active primary.
+       * </pre>
+       */
+      BACKUP(2, 2),
+      /**
+       * <code>IDLE = 3;</code>
+       *
+       * <pre>
+       * The replica is not active/opened.
+       * </pre>
+       */
+      IDLE(3, 3),
+      ;
+
+      /**
+       * <code>NONE = 0;</code>
+       *
+       * <pre>
+       * The replica doesn't use lease, or an error occured.
+       * </pre>
+       */
+      public static final int NONE_VALUE = 0;
+      /**
+       * <code>PRIMARY = 1;</code>
+       *
+       * <pre>
+       * The replica has been the primary.
+       * </pre>
+       */
+      public static final int PRIMARY_VALUE = 1;
+      /**
+       * <code>BACKUP = 2;</code>
+       *
+       * <pre>
+       * The replica has been a backup with an active primary.
+       * </pre>
+       */
+      public static final int BACKUP_VALUE = 2;
+      /**
+       * <code>IDLE = 3;</code>
+       *
+       * <pre>
+       * The replica is not active/opened.
+       * </pre>
+       */
+      public static final int IDLE_VALUE = 3;
+
+
+      public final int getNumber() { return value; }
+
+      public static LeaseState valueOf(int value) {
+        switch (value) {
+          case 0: return NONE;
+          case 1: return PRIMARY;
+          case 2: return BACKUP;
+          case 3: return IDLE;
+          default: return null;
+        }
+      }
+
+      public static com.google.protobuf.Internal.EnumLiteMap<LeaseState>
+          internalGetValueMap() {
+        return internalValueMap;
+      }
+      private static com.google.protobuf.Internal.EnumLiteMap<LeaseState>
+          internalValueMap =
+            new com.google.protobuf.Internal.EnumLiteMap<LeaseState>() {
+              public LeaseState findValueByNumber(int number) {
+                return LeaseState.valueOf(number);
+              }
+            };
+
+      public final com.google.protobuf.Descriptors.EnumValueDescriptor
+          getValueDescriptor() {
+        return getDescriptor().getValues().get(index);
+      }
+      public final com.google.protobuf.Descriptors.EnumDescriptor
+          getDescriptorForType() {
+        return getDescriptor();
+      }
+      public static final com.google.protobuf.Descriptors.EnumDescriptor
+          getDescriptor() {
+        return org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_xloc_set_invalidateResponse.getDescriptor().getEnumTypes().get(0);
+      }
+
+      private static final LeaseState[] VALUES = values();
+
+      public static LeaseState valueOf(
+          com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
+        if (desc.getType() != getDescriptor()) {
+          throw new java.lang.IllegalArgumentException(
+            "EnumValueDescriptor is not for this type.");
+        }
+        return VALUES[desc.getIndex()];
+      }
+
+      private final int index;
+      private final int value;
+
+      private LeaseState(int index, int value) {
+        this.index = index;
+        this.value = value;
+      }
+
+      // @@protoc_insertion_point(enum_scope:xtreemfs.pbrpc.xtreemfs_xloc_set_invalidateResponse.LeaseState)
+    }
+
+    private int bitField0_;
+    // required .xtreemfs.pbrpc.xtreemfs_xloc_set_invalidateResponse.LeaseState lease_state = 1;
+    public static final int LEASE_STATE_FIELD_NUMBER = 1;
+    private org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_xloc_set_invalidateResponse.LeaseState leaseState_;
+    /**
+     * <code>required .xtreemfs.pbrpc.xtreemfs_xloc_set_invalidateResponse.LeaseState lease_state = 1;</code>
+     */
+    public boolean hasLeaseState() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
-     * <code>required bool is_primary = 1;</code>
+     * <code>required .xtreemfs.pbrpc.xtreemfs_xloc_set_invalidateResponse.LeaseState lease_state = 1;</code>
      */
-    public boolean getIsPrimary() {
-      return isPrimary_;
+    public org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_xloc_set_invalidateResponse.LeaseState getLeaseState() {
+      return leaseState_;
     }
 
-    // optional .xtreemfs.pbrpc.ReplicaStatus status = 2;
-    public static final int STATUS_FIELD_NUMBER = 2;
-    private org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus status_;
+    // optional .xtreemfs.pbrpc.ReplicaStatus replica_status = 2;
+    public static final int REPLICA_STATUS_FIELD_NUMBER = 2;
+    private org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus replicaStatus_;
     /**
-     * <code>optional .xtreemfs.pbrpc.ReplicaStatus status = 2;</code>
+     * <code>optional .xtreemfs.pbrpc.ReplicaStatus replica_status = 2;</code>
      */
-    public boolean hasStatus() {
+    public boolean hasReplicaStatus() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
     }
     /**
-     * <code>optional .xtreemfs.pbrpc.ReplicaStatus status = 2;</code>
+     * <code>optional .xtreemfs.pbrpc.ReplicaStatus replica_status = 2;</code>
      */
-    public org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus getStatus() {
-      return status_;
+    public org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus getReplicaStatus() {
+      return replicaStatus_;
     }
     /**
-     * <code>optional .xtreemfs.pbrpc.ReplicaStatus status = 2;</code>
+     * <code>optional .xtreemfs.pbrpc.ReplicaStatus replica_status = 2;</code>
      */
-    public org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatusOrBuilder getStatusOrBuilder() {
-      return status_;
+    public org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatusOrBuilder getReplicaStatusOrBuilder() {
+      return replicaStatus_;
     }
 
     private void initFields() {
-      isPrimary_ = false;
-      status_ = org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus.getDefaultInstance();
+      leaseState_ = org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_xloc_set_invalidateResponse.LeaseState.NONE;
+      replicaStatus_ = org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus.getDefaultInstance();
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized != -1) return isInitialized == 1;
 
-      if (!hasIsPrimary()) {
+      if (!hasLeaseState()) {
         memoizedIsInitialized = 0;
         return false;
       }
-      if (hasStatus()) {
-        if (!getStatus().isInitialized()) {
+      if (hasReplicaStatus()) {
+        if (!getReplicaStatus().isInitialized()) {
           memoizedIsInitialized = 0;
           return false;
         }
@@ -32291,10 +32429,10 @@ public final class OSD {
                         throws java.io.IOException {
       getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeBool(1, isPrimary_);
+        output.writeEnum(1, leaseState_.getNumber());
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        output.writeMessage(2, status_);
+        output.writeMessage(2, replicaStatus_);
       }
       getUnknownFields().writeTo(output);
     }
@@ -32307,11 +32445,11 @@ public final class OSD {
       size = 0;
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeBoolSize(1, isPrimary_);
+          .computeEnumSize(1, leaseState_.getNumber());
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(2, status_);
+          .computeMessageSize(2, replicaStatus_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -32421,7 +32559,7 @@ public final class OSD {
       }
       private void maybeForceBuilderInitialization() {
         if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
-          getStatusFieldBuilder();
+          getReplicaStatusFieldBuilder();
         }
       }
       private static Builder create() {
@@ -32430,12 +32568,12 @@ public final class OSD {
 
       public Builder clear() {
         super.clear();
-        isPrimary_ = false;
+        leaseState_ = org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_xloc_set_invalidateResponse.LeaseState.NONE;
         bitField0_ = (bitField0_ & ~0x00000001);
-        if (statusBuilder_ == null) {
-          status_ = org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus.getDefaultInstance();
+        if (replicaStatusBuilder_ == null) {
+          replicaStatus_ = org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus.getDefaultInstance();
         } else {
-          statusBuilder_.clear();
+          replicaStatusBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000002);
         return this;
@@ -32469,14 +32607,14 @@ public final class OSD {
         if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
           to_bitField0_ |= 0x00000001;
         }
-        result.isPrimary_ = isPrimary_;
+        result.leaseState_ = leaseState_;
         if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
           to_bitField0_ |= 0x00000002;
         }
-        if (statusBuilder_ == null) {
-          result.status_ = status_;
+        if (replicaStatusBuilder_ == null) {
+          result.replicaStatus_ = replicaStatus_;
         } else {
-          result.status_ = statusBuilder_.build();
+          result.replicaStatus_ = replicaStatusBuilder_.build();
         }
         result.bitField0_ = to_bitField0_;
         onBuilt();
@@ -32494,23 +32632,23 @@ public final class OSD {
 
       public Builder mergeFrom(org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_xloc_set_invalidateResponse other) {
         if (other == org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_xloc_set_invalidateResponse.getDefaultInstance()) return this;
-        if (other.hasIsPrimary()) {
-          setIsPrimary(other.getIsPrimary());
+        if (other.hasLeaseState()) {
+          setLeaseState(other.getLeaseState());
         }
-        if (other.hasStatus()) {
-          mergeStatus(other.getStatus());
+        if (other.hasReplicaStatus()) {
+          mergeReplicaStatus(other.getReplicaStatus());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
       }
 
       public final boolean isInitialized() {
-        if (!hasIsPrimary()) {
+        if (!hasLeaseState()) {
           
           return false;
         }
-        if (hasStatus()) {
-          if (!getStatus().isInitialized()) {
+        if (hasReplicaStatus()) {
+          if (!getReplicaStatus().isInitialized()) {
             
             return false;
           }
@@ -32537,154 +32675,157 @@ public final class OSD {
       }
       private int bitField0_;
 
-      // required bool is_primary = 1;
-      private boolean isPrimary_ ;
+      // required .xtreemfs.pbrpc.xtreemfs_xloc_set_invalidateResponse.LeaseState lease_state = 1;
+      private org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_xloc_set_invalidateResponse.LeaseState leaseState_ = org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_xloc_set_invalidateResponse.LeaseState.NONE;
       /**
-       * <code>required bool is_primary = 1;</code>
+       * <code>required .xtreemfs.pbrpc.xtreemfs_xloc_set_invalidateResponse.LeaseState lease_state = 1;</code>
        */
-      public boolean hasIsPrimary() {
+      public boolean hasLeaseState() {
         return ((bitField0_ & 0x00000001) == 0x00000001);
       }
       /**
-       * <code>required bool is_primary = 1;</code>
+       * <code>required .xtreemfs.pbrpc.xtreemfs_xloc_set_invalidateResponse.LeaseState lease_state = 1;</code>
        */
-      public boolean getIsPrimary() {
-        return isPrimary_;
+      public org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_xloc_set_invalidateResponse.LeaseState getLeaseState() {
+        return leaseState_;
       }
       /**
-       * <code>required bool is_primary = 1;</code>
+       * <code>required .xtreemfs.pbrpc.xtreemfs_xloc_set_invalidateResponse.LeaseState lease_state = 1;</code>
        */
-      public Builder setIsPrimary(boolean value) {
+      public Builder setLeaseState(org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_xloc_set_invalidateResponse.LeaseState value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
         bitField0_ |= 0x00000001;
-        isPrimary_ = value;
+        leaseState_ = value;
         onChanged();
         return this;
       }
       /**
-       * <code>required bool is_primary = 1;</code>
+       * <code>required .xtreemfs.pbrpc.xtreemfs_xloc_set_invalidateResponse.LeaseState lease_state = 1;</code>
        */
-      public Builder clearIsPrimary() {
+      public Builder clearLeaseState() {
         bitField0_ = (bitField0_ & ~0x00000001);
-        isPrimary_ = false;
+        leaseState_ = org.xtreemfs.pbrpc.generatedinterfaces.OSD.xtreemfs_xloc_set_invalidateResponse.LeaseState.NONE;
         onChanged();
         return this;
       }
 
-      // optional .xtreemfs.pbrpc.ReplicaStatus status = 2;
-      private org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus status_ = org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus.getDefaultInstance();
+      // optional .xtreemfs.pbrpc.ReplicaStatus replica_status = 2;
+      private org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus replicaStatus_ = org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
-          org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus, org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus.Builder, org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatusOrBuilder> statusBuilder_;
+          org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus, org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus.Builder, org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatusOrBuilder> replicaStatusBuilder_;
       /**
-       * <code>optional .xtreemfs.pbrpc.ReplicaStatus status = 2;</code>
+       * <code>optional .xtreemfs.pbrpc.ReplicaStatus replica_status = 2;</code>
        */
-      public boolean hasStatus() {
+      public boolean hasReplicaStatus() {
         return ((bitField0_ & 0x00000002) == 0x00000002);
       }
       /**
-       * <code>optional .xtreemfs.pbrpc.ReplicaStatus status = 2;</code>
+       * <code>optional .xtreemfs.pbrpc.ReplicaStatus replica_status = 2;</code>
        */
-      public org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus getStatus() {
-        if (statusBuilder_ == null) {
-          return status_;
+      public org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus getReplicaStatus() {
+        if (replicaStatusBuilder_ == null) {
+          return replicaStatus_;
         } else {
-          return statusBuilder_.getMessage();
+          return replicaStatusBuilder_.getMessage();
         }
       }
       /**
-       * <code>optional .xtreemfs.pbrpc.ReplicaStatus status = 2;</code>
+       * <code>optional .xtreemfs.pbrpc.ReplicaStatus replica_status = 2;</code>
        */
-      public Builder setStatus(org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus value) {
-        if (statusBuilder_ == null) {
+      public Builder setReplicaStatus(org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus value) {
+        if (replicaStatusBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
           }
-          status_ = value;
+          replicaStatus_ = value;
           onChanged();
         } else {
-          statusBuilder_.setMessage(value);
+          replicaStatusBuilder_.setMessage(value);
         }
         bitField0_ |= 0x00000002;
         return this;
       }
       /**
-       * <code>optional .xtreemfs.pbrpc.ReplicaStatus status = 2;</code>
+       * <code>optional .xtreemfs.pbrpc.ReplicaStatus replica_status = 2;</code>
        */
-      public Builder setStatus(
+      public Builder setReplicaStatus(
           org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus.Builder builderForValue) {
-        if (statusBuilder_ == null) {
-          status_ = builderForValue.build();
+        if (replicaStatusBuilder_ == null) {
+          replicaStatus_ = builderForValue.build();
           onChanged();
         } else {
-          statusBuilder_.setMessage(builderForValue.build());
+          replicaStatusBuilder_.setMessage(builderForValue.build());
         }
         bitField0_ |= 0x00000002;
         return this;
       }
       /**
-       * <code>optional .xtreemfs.pbrpc.ReplicaStatus status = 2;</code>
+       * <code>optional .xtreemfs.pbrpc.ReplicaStatus replica_status = 2;</code>
        */
-      public Builder mergeStatus(org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus value) {
-        if (statusBuilder_ == null) {
+      public Builder mergeReplicaStatus(org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus value) {
+        if (replicaStatusBuilder_ == null) {
           if (((bitField0_ & 0x00000002) == 0x00000002) &&
-              status_ != org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus.getDefaultInstance()) {
-            status_ =
-              org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus.newBuilder(status_).mergeFrom(value).buildPartial();
+              replicaStatus_ != org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus.getDefaultInstance()) {
+            replicaStatus_ =
+              org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus.newBuilder(replicaStatus_).mergeFrom(value).buildPartial();
           } else {
-            status_ = value;
+            replicaStatus_ = value;
           }
           onChanged();
         } else {
-          statusBuilder_.mergeFrom(value);
+          replicaStatusBuilder_.mergeFrom(value);
         }
         bitField0_ |= 0x00000002;
         return this;
       }
       /**
-       * <code>optional .xtreemfs.pbrpc.ReplicaStatus status = 2;</code>
+       * <code>optional .xtreemfs.pbrpc.ReplicaStatus replica_status = 2;</code>
        */
-      public Builder clearStatus() {
-        if (statusBuilder_ == null) {
-          status_ = org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus.getDefaultInstance();
+      public Builder clearReplicaStatus() {
+        if (replicaStatusBuilder_ == null) {
+          replicaStatus_ = org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus.getDefaultInstance();
           onChanged();
         } else {
-          statusBuilder_.clear();
+          replicaStatusBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000002);
         return this;
       }
       /**
-       * <code>optional .xtreemfs.pbrpc.ReplicaStatus status = 2;</code>
+       * <code>optional .xtreemfs.pbrpc.ReplicaStatus replica_status = 2;</code>
        */
-      public org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus.Builder getStatusBuilder() {
+      public org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus.Builder getReplicaStatusBuilder() {
         bitField0_ |= 0x00000002;
         onChanged();
-        return getStatusFieldBuilder().getBuilder();
+        return getReplicaStatusFieldBuilder().getBuilder();
       }
       /**
-       * <code>optional .xtreemfs.pbrpc.ReplicaStatus status = 2;</code>
+       * <code>optional .xtreemfs.pbrpc.ReplicaStatus replica_status = 2;</code>
        */
-      public org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatusOrBuilder getStatusOrBuilder() {
-        if (statusBuilder_ != null) {
-          return statusBuilder_.getMessageOrBuilder();
+      public org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatusOrBuilder getReplicaStatusOrBuilder() {
+        if (replicaStatusBuilder_ != null) {
+          return replicaStatusBuilder_.getMessageOrBuilder();
         } else {
-          return status_;
+          return replicaStatus_;
         }
       }
       /**
-       * <code>optional .xtreemfs.pbrpc.ReplicaStatus status = 2;</code>
+       * <code>optional .xtreemfs.pbrpc.ReplicaStatus replica_status = 2;</code>
        */
       private com.google.protobuf.SingleFieldBuilder<
           org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus, org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus.Builder, org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatusOrBuilder> 
-          getStatusFieldBuilder() {
-        if (statusBuilder_ == null) {
-          statusBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+          getReplicaStatusFieldBuilder() {
+        if (replicaStatusBuilder_ == null) {
+          replicaStatusBuilder_ = new com.google.protobuf.SingleFieldBuilder<
               org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus, org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatus.Builder, org.xtreemfs.pbrpc.generatedinterfaces.OSD.ReplicaStatusOrBuilder>(
-                  status_,
+                  replicaStatus_,
                   getParentForChildren(),
                   isClean());
-          status_ = null;
+          replicaStatus_ = null;
         }
-        return statusBuilder_;
+        return replicaStatusBuilder_;
       }
 
       // @@protoc_insertion_point(builder_scope:xtreemfs.pbrpc.xtreemfs_xloc_set_invalidateResponse)
@@ -33037,111 +33178,115 @@ public final class OSD {
       "\003 \002(\007\"q\n#xtreemfs_xloc_set_invalidateReq" +
       "uest\0229\n\020file_credentials\030\001 \002(\0132\037.xtreemf" +
       "s.pbrpc.FileCredentials\022\017\n\007file_id\030\002 \002(\t" +
-      "\"i\n$xtreemfs_xloc_set_invalidateResponse" +
-      "\022\022\n\nis_primary\030\001 \002(\010\022-\n\006status\030\002 \001(\0132\035.x" +
-      "treemfs.pbrpc.ReplicaStatus*\215\001\n\017OSDHealt" +
-      "hResult\022\034\n\030OSD_HEALTH_RESULT_PASSED\020\000\022\035\n" +
-      "\031OSD_HEALTH_RESULT_WARNING\020\001\022\034\n\030OSD_HEAL",
-      "TH_RESULT_FAILED\020\002\022\037\n\033OSD_HEALTH_RESULT_" +
-      "NOT_AVAIL\020\0032\277\036\n\nOSDService\022L\n\004read\022\033.xtr" +
-      "eemfs.pbrpc.readRequest\032\032.xtreemfs.pbrpc" +
-      ".ObjectData\"\013\215\265\030\n\000\000\000\230\265\030\001\022V\n\010truncate\022\037.x" +
-      "treemfs.pbrpc.truncateRequest\032 .xtreemfs" +
-      ".pbrpc.OSDWriteResponse\"\007\215\265\030\013\000\000\000\022T\n\006unli" +
-      "nk\022\".xtreemfs.pbrpc.unlink_osd_Request\032\035" +
-      ".xtreemfs.pbrpc.emptyResponse\"\007\215\265\030\014\000\000\000\022T" +
-      "\n\005write\022\034.xtreemfs.pbrpc.writeRequest\032 ." +
-      "xtreemfs.pbrpc.OSDWriteResponse\"\013\215\265\030\r\000\000\000",
-      "\240\265\030\001\022q\n\027xtreemfs_broadcast_gmax\022..xtreem" +
-      "fs.pbrpc.xtreemfs_broadcast_gmaxRequest\032" +
-      "\035.xtreemfs.pbrpc.emptyResponse\"\007\215\265\030\024\000\000\000\022" +
-      "j\n\025xtreemfs_check_object\022,.xtreemfs.pbrp" +
-      "c.xtreemfs_check_objectRequest\032\032.xtreemf" +
-      "s.pbrpc.ObjectData\"\007\215\265\030\025\000\000\000\022{\n\034xtreemfs_" +
-      "cleanup_get_results\022\034.xtreemfs.pbrpc.emp" +
-      "tyRequest\0324.xtreemfs.pbrpc.xtreemfs_clea" +
-      "nup_get_resultsResponse\"\007\215\265\030\036\000\000\000\022y\n\033xtre" +
-      "emfs_cleanup_is_running\022\034.xtreemfs.pbrpc",
-      ".emptyRequest\0323.xtreemfs.pbrpc.xtreemfs_" +
-      "cleanup_is_runningResponse\"\007\215\265\030\037\000\000\000\022o\n\026x" +
-      "treemfs_cleanup_start\022-.xtreemfs.pbrpc.x" +
-      "treemfs_cleanup_startRequest\032\035.xtreemfs." +
-      "pbrpc.emptyResponse\"\007\215\265\030 \000\000\000\022q\n\027xtreemfs" +
-      "_cleanup_status\022\034.xtreemfs.pbrpc.emptyRe" +
-      "quest\032/.xtreemfs.pbrpc.xtreemfs_cleanup_" +
-      "statusResponse\"\007\215\265\030!\000\000\000\022]\n\025xtreemfs_clea" +
-      "nup_stop\022\034.xtreemfs.pbrpc.emptyRequest\032\035" +
-      ".xtreemfs.pbrpc.emptyResponse\"\007\215\265\030\"\000\000\000\022g",
-      "\n\037xtreemfs_cleanup_versions_start\022\034.xtre" +
-      "emfs.pbrpc.emptyRequest\032\035.xtreemfs.pbrpc" +
-      ".emptyResponse\"\007\215\265\030#\000\000\000\022o\n\026xtreemfs_repa" +
-      "ir_object\022-.xtreemfs.pbrpc.xtreemfs_repa" +
-      "ir_objectRequest\032\035.xtreemfs.pbrpc.emptyR" +
-      "esponse\"\007\215\265\030$\000\000\000\022d\n\022xtreemfs_rwr_fetch\022)" +
-      ".xtreemfs.pbrpc.xtreemfs_rwr_fetchReques" +
-      "t\032\032.xtreemfs.pbrpc.ObjectData\"\007\215\265\030I\000\000\000\022u" +
-      "\n\027xtreemfs_rwr_flease_msg\022..xtreemfs.pbr" +
-      "pc.xtreemfs_rwr_flease_msgRequest\032\035.xtre",
-      "emfs.pbrpc.emptyResponse\"\013\215\265\030G\000\000\000\240\265\030\001\022^\n" +
-      "\023xtreemfs_rwr_notify\022\037.xtreemfs.pbrpc.Fi" +
-      "leCredentials\032\035.xtreemfs.pbrpc.emptyResp" +
-      "onse\"\007\215\265\030K\000\000\000\022|\n\036xtreemfs_rwr_set_primar" +
-      "y_epoch\0225.xtreemfs.pbrpc.xtreemfs_rwr_se" +
-      "t_primary_epochRequest\032\032.xtreemfs.pbrpc." +
-      "ObjectData\"\007\215\265\030N\000\000\000\022i\n\023xtreemfs_rwr_stat" +
-      "us\022*.xtreemfs.pbrpc.xtreemfs_rwr_statusR" +
-      "equest\032\035.xtreemfs.pbrpc.ReplicaStatus\"\007\215" +
-      "\265\030L\000\000\000\022m\n\025xtreemfs_rwr_truncate\022,.xtreem",
-      "fs.pbrpc.xtreemfs_rwr_truncateRequest\032\035." +
-      "xtreemfs.pbrpc.emptyResponse\"\007\215\265\030J\000\000\000\022m\n" +
-      "\023xtreemfs_rwr_update\022*.xtreemfs.pbrpc.xt" +
-      "reemfs_rwr_updateRequest\032\035.xtreemfs.pbrp" +
-      "c.emptyResponse\"\013\215\265\030H\000\000\000\240\265\030\001\022q\n\027xtreemfs" +
-      "_rwr_auth_state\022..xtreemfs.pbrpc.xtreemf" +
-      "s_rwr_auth_stateRequest\032\035.xtreemfs.pbrpc" +
-      ".emptyResponse\"\007\215\265\030O\000\000\000\022y\n\033xtreemfs_rwr_" +
-      "reset_complete\0222.xtreemfs.pbrpc.xtreemfs" +
-      "_rwr_reset_completeRequest\032\035.xtreemfs.pb",
-      "rpc.emptyResponse\"\007\215\265\030P\000\000\000\022v\n\032xtreemfs_i" +
-      "nternal_get_gmax\0221.xtreemfs.pbrpc.xtreem" +
-      "fs_internal_get_gmaxRequest\032\034.xtreemfs.p" +
-      "brpc.InternalGmax\"\007\215\265\030(\000\000\000\022h\n\032xtreemfs_i" +
-      "nternal_truncate\022\037.xtreemfs.pbrpc.trunca" +
-      "teRequest\032 .xtreemfs.pbrpc.OSDWriteRespo" +
-      "nse\"\007\215\265\030)\000\000\000\022\233\001\n\037xtreemfs_internal_get_f" +
-      "ile_size\0226.xtreemfs.pbrpc.xtreemfs_inter" +
-      "nal_get_file_sizeRequest\0327.xtreemfs.pbrp" +
-      "c.xtreemfs_internal_get_file_sizeRespons",
-      "e\"\007\215\265\030*\000\000\000\022\207\001\n\034xtreemfs_internal_read_lo" +
-      "cal\0223.xtreemfs.pbrpc.xtreemfs_internal_r" +
-      "ead_localRequest\032).xtreemfs.pbrpc.Intern" +
-      "alReadLocalResponse\"\007\215\265\030+\000\000\000\022\200\001\n xtreemf" +
-      "s_internal_get_object_set\0227.xtreemfs.pbr" +
-      "pc.xtreemfs_internal_get_object_setReque" +
-      "st\032\032.xtreemfs.pbrpc.ObjectList\"\007\215\265\030,\000\000\000\022" +
-      "\205\001\n!xtreemfs_internal_get_fileid_list\022\034." +
-      "xtreemfs.pbrpc.emptyRequest\0329.xtreemfs.p" +
-      "brpc.xtreemfs_internal_get_fileid_listRe",
-      "sponse\"\007\215\265\030-\000\000\000\022S\n\025xtreemfs_lock_acquire" +
-      "\022\033.xtreemfs.pbrpc.lockRequest\032\024.xtreemfs" +
-      ".pbrpc.Lock\"\007\215\265\0302\000\000\000\022Q\n\023xtreemfs_lock_ch" +
-      "eck\022\033.xtreemfs.pbrpc.lockRequest\032\024.xtree" +
-      "mfs.pbrpc.Lock\"\007\215\265\0303\000\000\000\022\\\n\025xtreemfs_lock" +
-      "_release\022\033.xtreemfs.pbrpc.lockRequest\032\035." +
-      "xtreemfs.pbrpc.emptyResponse\"\007\215\265\0304\000\000\000\022f\n" +
-      "\rxtreemfs_ping\022%.xtreemfs.pbrpc.xtreemfs" +
-      "_pingMesssage\032%.xtreemfs.pbrpc.xtreemfs_" +
-      "pingMesssage\"\007\215\265\030<\000\000\000\022Y\n\021xtreemfs_shutdo",
-      "wn\022\034.xtreemfs.pbrpc.emptyRequest\032\035.xtree" +
-      "mfs.pbrpc.emptyResponse\"\007\215\265\030F\000\000\000\022\222\001\n\034xtr" +
-      "eemfs_xloc_set_invalidate\0223.xtreemfs.pbr" +
-      "pc.xtreemfs_xloc_set_invalidateRequest\0324" +
-      ".xtreemfs.pbrpc.xtreemfs_xloc_set_invali" +
-      "dateResponse\"\007\215\265\030Q\000\000\000\022}\n#xtreemfs_rwr_au" +
-      "th_state_invalidated\022..xtreemfs.pbrpc.xt" +
-      "reemfs_rwr_auth_stateRequest\032\035.xtreemfs." +
-      "pbrpc.emptyResponse\"\007\215\265\030R\000\000\000\032\007\225\265\0301u\000\000B(\n" +
-      "&org.xtreemfs.pbrpc.generatedinterfaces"
+      "\"\356\001\n$xtreemfs_xloc_set_invalidateRespons" +
+      "e\022T\n\013lease_state\030\001 \002(\0162?.xtreemfs.pbrpc." +
+      "xtreemfs_xloc_set_invalidateResponse.Lea" +
+      "seState\0225\n\016replica_status\030\002 \001(\0132\035.xtreem" +
+      "fs.pbrpc.ReplicaStatus\"9\n\nLeaseState\022\010\n\004",
+      "NONE\020\000\022\013\n\007PRIMARY\020\001\022\n\n\006BACKUP\020\002\022\010\n\004IDLE\020" +
+      "\003*\215\001\n\017OSDHealthResult\022\034\n\030OSD_HEALTH_RESU" +
+      "LT_PASSED\020\000\022\035\n\031OSD_HEALTH_RESULT_WARNING" +
+      "\020\001\022\034\n\030OSD_HEALTH_RESULT_FAILED\020\002\022\037\n\033OSD_" +
+      "HEALTH_RESULT_NOT_AVAIL\020\0032\277\036\n\nOSDService" +
+      "\022L\n\004read\022\033.xtreemfs.pbrpc.readRequest\032\032." +
+      "xtreemfs.pbrpc.ObjectData\"\013\215\265\030\n\000\000\000\230\265\030\001\022V" +
+      "\n\010truncate\022\037.xtreemfs.pbrpc.truncateRequ" +
+      "est\032 .xtreemfs.pbrpc.OSDWriteResponse\"\007\215" +
+      "\265\030\013\000\000\000\022T\n\006unlink\022\".xtreemfs.pbrpc.unlink",
+      "_osd_Request\032\035.xtreemfs.pbrpc.emptyRespo" +
+      "nse\"\007\215\265\030\014\000\000\000\022T\n\005write\022\034.xtreemfs.pbrpc.w" +
+      "riteRequest\032 .xtreemfs.pbrpc.OSDWriteRes" +
+      "ponse\"\013\215\265\030\r\000\000\000\240\265\030\001\022q\n\027xtreemfs_broadcast" +
+      "_gmax\022..xtreemfs.pbrpc.xtreemfs_broadcas" +
+      "t_gmaxRequest\032\035.xtreemfs.pbrpc.emptyResp" +
+      "onse\"\007\215\265\030\024\000\000\000\022j\n\025xtreemfs_check_object\022," +
+      ".xtreemfs.pbrpc.xtreemfs_check_objectReq" +
+      "uest\032\032.xtreemfs.pbrpc.ObjectData\"\007\215\265\030\025\000\000" +
+      "\000\022{\n\034xtreemfs_cleanup_get_results\022\034.xtre",
+      "emfs.pbrpc.emptyRequest\0324.xtreemfs.pbrpc" +
+      ".xtreemfs_cleanup_get_resultsResponse\"\007\215" +
+      "\265\030\036\000\000\000\022y\n\033xtreemfs_cleanup_is_running\022\034." +
+      "xtreemfs.pbrpc.emptyRequest\0323.xtreemfs.p" +
+      "brpc.xtreemfs_cleanup_is_runningResponse" +
+      "\"\007\215\265\030\037\000\000\000\022o\n\026xtreemfs_cleanup_start\022-.xt" +
+      "reemfs.pbrpc.xtreemfs_cleanup_startReque" +
+      "st\032\035.xtreemfs.pbrpc.emptyResponse\"\007\215\265\030 \000" +
+      "\000\000\022q\n\027xtreemfs_cleanup_status\022\034.xtreemfs" +
+      ".pbrpc.emptyRequest\032/.xtreemfs.pbrpc.xtr",
+      "eemfs_cleanup_statusResponse\"\007\215\265\030!\000\000\000\022]\n" +
+      "\025xtreemfs_cleanup_stop\022\034.xtreemfs.pbrpc." +
+      "emptyRequest\032\035.xtreemfs.pbrpc.emptyRespo" +
+      "nse\"\007\215\265\030\"\000\000\000\022g\n\037xtreemfs_cleanup_version" +
+      "s_start\022\034.xtreemfs.pbrpc.emptyRequest\032\035." +
+      "xtreemfs.pbrpc.emptyResponse\"\007\215\265\030#\000\000\000\022o\n" +
+      "\026xtreemfs_repair_object\022-.xtreemfs.pbrpc" +
+      ".xtreemfs_repair_objectRequest\032\035.xtreemf" +
+      "s.pbrpc.emptyResponse\"\007\215\265\030$\000\000\000\022d\n\022xtreem" +
+      "fs_rwr_fetch\022).xtreemfs.pbrpc.xtreemfs_r",
+      "wr_fetchRequest\032\032.xtreemfs.pbrpc.ObjectD" +
+      "ata\"\007\215\265\030I\000\000\000\022u\n\027xtreemfs_rwr_flease_msg\022" +
+      "..xtreemfs.pbrpc.xtreemfs_rwr_flease_msg" +
+      "Request\032\035.xtreemfs.pbrpc.emptyResponse\"\013" +
+      "\215\265\030G\000\000\000\240\265\030\001\022^\n\023xtreemfs_rwr_notify\022\037.xtr" +
+      "eemfs.pbrpc.FileCredentials\032\035.xtreemfs.p" +
+      "brpc.emptyResponse\"\007\215\265\030K\000\000\000\022|\n\036xtreemfs_" +
+      "rwr_set_primary_epoch\0225.xtreemfs.pbrpc.x" +
+      "treemfs_rwr_set_primary_epochRequest\032\032.x" +
+      "treemfs.pbrpc.ObjectData\"\007\215\265\030N\000\000\000\022i\n\023xtr",
+      "eemfs_rwr_status\022*.xtreemfs.pbrpc.xtreem" +
+      "fs_rwr_statusRequest\032\035.xtreemfs.pbrpc.Re" +
+      "plicaStatus\"\007\215\265\030L\000\000\000\022m\n\025xtreemfs_rwr_tru" +
+      "ncate\022,.xtreemfs.pbrpc.xtreemfs_rwr_trun" +
+      "cateRequest\032\035.xtreemfs.pbrpc.emptyRespon" +
+      "se\"\007\215\265\030J\000\000\000\022m\n\023xtreemfs_rwr_update\022*.xtr" +
+      "eemfs.pbrpc.xtreemfs_rwr_updateRequest\032\035" +
+      ".xtreemfs.pbrpc.emptyResponse\"\013\215\265\030H\000\000\000\240\265" +
+      "\030\001\022q\n\027xtreemfs_rwr_auth_state\022..xtreemfs" +
+      ".pbrpc.xtreemfs_rwr_auth_stateRequest\032\035.",
+      "xtreemfs.pbrpc.emptyResponse\"\007\215\265\030O\000\000\000\022y\n" +
+      "\033xtreemfs_rwr_reset_complete\0222.xtreemfs." +
+      "pbrpc.xtreemfs_rwr_reset_completeRequest" +
+      "\032\035.xtreemfs.pbrpc.emptyResponse\"\007\215\265\030P\000\000\000" +
+      "\022v\n\032xtreemfs_internal_get_gmax\0221.xtreemf" +
+      "s.pbrpc.xtreemfs_internal_get_gmaxReques" +
+      "t\032\034.xtreemfs.pbrpc.InternalGmax\"\007\215\265\030(\000\000\000" +
+      "\022h\n\032xtreemfs_internal_truncate\022\037.xtreemf" +
+      "s.pbrpc.truncateRequest\032 .xtreemfs.pbrpc" +
+      ".OSDWriteResponse\"\007\215\265\030)\000\000\000\022\233\001\n\037xtreemfs_",
+      "internal_get_file_size\0226.xtreemfs.pbrpc." +
+      "xtreemfs_internal_get_file_sizeRequest\0327" +
+      ".xtreemfs.pbrpc.xtreemfs_internal_get_fi" +
+      "le_sizeResponse\"\007\215\265\030*\000\000\000\022\207\001\n\034xtreemfs_in" +
+      "ternal_read_local\0223.xtreemfs.pbrpc.xtree" +
+      "mfs_internal_read_localRequest\032).xtreemf" +
+      "s.pbrpc.InternalReadLocalResponse\"\007\215\265\030+\000" +
+      "\000\000\022\200\001\n xtreemfs_internal_get_object_set\022" +
+      "7.xtreemfs.pbrpc.xtreemfs_internal_get_o" +
+      "bject_setRequest\032\032.xtreemfs.pbrpc.Object",
+      "List\"\007\215\265\030,\000\000\000\022\205\001\n!xtreemfs_internal_get_" +
+      "fileid_list\022\034.xtreemfs.pbrpc.emptyReques" +
+      "t\0329.xtreemfs.pbrpc.xtreemfs_internal_get" +
+      "_fileid_listResponse\"\007\215\265\030-\000\000\000\022S\n\025xtreemf" +
+      "s_lock_acquire\022\033.xtreemfs.pbrpc.lockRequ" +
+      "est\032\024.xtreemfs.pbrpc.Lock\"\007\215\265\0302\000\000\000\022Q\n\023xt" +
+      "reemfs_lock_check\022\033.xtreemfs.pbrpc.lockR" +
+      "equest\032\024.xtreemfs.pbrpc.Lock\"\007\215\265\0303\000\000\000\022\\\n" +
+      "\025xtreemfs_lock_release\022\033.xtreemfs.pbrpc." +
+      "lockRequest\032\035.xtreemfs.pbrpc.emptyRespon",
+      "se\"\007\215\265\0304\000\000\000\022f\n\rxtreemfs_ping\022%.xtreemfs." +
+      "pbrpc.xtreemfs_pingMesssage\032%.xtreemfs.p" +
+      "brpc.xtreemfs_pingMesssage\"\007\215\265\030<\000\000\000\022Y\n\021x" +
+      "treemfs_shutdown\022\034.xtreemfs.pbrpc.emptyR" +
+      "equest\032\035.xtreemfs.pbrpc.emptyResponse\"\007\215" +
+      "\265\030F\000\000\000\022\222\001\n\034xtreemfs_xloc_set_invalidate\022" +
+      "3.xtreemfs.pbrpc.xtreemfs_xloc_set_inval" +
+      "idateRequest\0324.xtreemfs.pbrpc.xtreemfs_x" +
+      "loc_set_invalidateResponse\"\007\215\265\030Q\000\000\000\022}\n#x" +
+      "treemfs_rwr_auth_state_invalidated\022..xtr",
+      "eemfs.pbrpc.xtreemfs_rwr_auth_stateReque" +
+      "st\032\035.xtreemfs.pbrpc.emptyResponse\"\007\215\265\030R\000" +
+      "\000\000\032\007\225\265\0301u\000\000B(\n&org.xtreemfs.pbrpc.genera" +
+      "tedinterfaces"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -33393,7 +33538,7 @@ public final class OSD {
           internal_static_xtreemfs_pbrpc_xtreemfs_xloc_set_invalidateResponse_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_xtreemfs_pbrpc_xtreemfs_xloc_set_invalidateResponse_descriptor,
-              new java.lang.String[] { "IsPrimary", "Status", });
+              new java.lang.String[] { "LeaseState", "ReplicaStatus", });
           com.google.protobuf.ExtensionRegistry registry =
             com.google.protobuf.ExtensionRegistry.newInstance();
           registry.add(org.xtreemfs.foundation.pbrpc.generatedinterfaces.PBRPC.procId);


### PR DESCRIPTION
Before the invalidation method had to wait until
1) a majority did respond and
2) either the primary or all replicas did respond
   or in case both could not be satisfied, until the lease did time out.

This did result in long delays if either 1) no primary was elected at the time
of invalidation and at least one replica was unreachable, or 2) the primary
itself did not respond.

With this commit an additional LeaseState is returned with invalidation
responses, which allows to determine if a primary did exist at all and fixes
delays as described in the first case.